### PR TITLE
Fixed nested schemas

### DIFF
--- a/avrohugger-core/src/main/scala/FileParser.scala
+++ b/avrohugger-core/src/main/scala/FileParser.scala
@@ -41,12 +41,12 @@ class FileParser {
 
   def getNestedSchemas(schema: Schema): List[Schema] = {
     val fields: List[org.apache.avro.Schema.Field] = schema.getFields.asScala.toList
-    val fieldSchemas:List[org.apache.avro.Schema]  = fields.map(field => field.schema())
+    val fieldSchemas: List[org.apache.avro.Schema] = fields.map(field => field.schema())
 
     def flattenSchema(fieldSchema: Schema): List[Schema] = {
       fieldSchema.getType match {
         case ARRAY  => flattenSchema(fieldSchema.getElementType)
-        case RECORD => getNestedSchemas(fieldSchema); List(fieldSchema)
+        case RECORD => fieldSchema :: getNestedSchemas(fieldSchema)
         case UNION  => fieldSchema.getTypes.asScala.toList.flatMap(x => flattenSchema(x))
         case _      => List(fieldSchema)
       }

--- a/avrohugger-core/src/test/avro/nested.avsc
+++ b/avrohugger-core/src/test/avro/nested.avsc
@@ -1,0 +1,29 @@
+{
+  "namespace": "example",
+  "type": "record",
+  "name": "Level0",
+  "fields": [
+    {
+      "name": "level1",
+      "type": {
+        "name": "Level1",
+        "type": "record",
+        "fields": [
+          {
+            "name": "level2",
+            "type": {
+              "name": "Level2",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "name",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/avrohugger-core/src/test/scala/GeneratorSpec.scala
+++ b/avrohugger-core/src/test/scala/GeneratorSpec.scala
@@ -7,21 +7,52 @@ import specification._
 class GeneratorSpec extends mutable.Specification {
 
   "a Generator" should {
-    
+
     "correctly generate a simple case class definition in a package" in {
       val infile = new java.io.File("avrohugger-core/src/test/avro/twitter.avro")
       val gen = new Generator
       gen.fromFile(infile)
       val source = scala.io.Source.fromFile("target/generated-sources/com/miguno/avro/twitter_schema.scala").mkString
       println(source)
-       source === 
-"""/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+      source ===
+        """/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package com.miguno.avro
 
 case class twitter_schema(username: String, tweet: String, timestamp: Long)"""
     }
-    
-    
+
+    "correctly generate a nested case class definition" in {
+      val infile = new java.io.File("avrohugger-core/src/test/avro/nested.avsc")
+      val gen = new Generator
+      gen.fromFile(infile)
+
+      val source0 = scala.io.Source.fromFile("target/generated-sources/example/Level0.scala").mkString
+      source0 ====
+        """
+          |/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+          |package example
+          |
+          |case class Level0(level1: Level1)
+        """.stripMargin.trim
+
+      val source1 = scala.io.Source.fromFile("target/generated-sources/example/Level1.scala").mkString
+      source1 ====
+        """
+          |/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+          |package example
+          |
+          |case class Level1(level2: Level2)
+        """.stripMargin.trim
+
+      val source2 = scala.io.Source.fromFile("target/generated-sources/example/Level2.scala").mkString
+      source2 ====
+        """
+          |/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+          |package example
+          |
+          |case class Level2(name: String)
+        """.stripMargin.trim
+    }
   }
 }
 


### PR DESCRIPTION
Currently avrohugger does not generate classes for nested schemas. If I understand correctly, the result of parsing nested schemas is currently thrown away. Here's a fix for that that works with my admittedly simple test case.
