### PR TITLE
Solution for Issue #13. Duplicated classes generated when importing schemas from different namespaces

### DIFF
--- a/avrohugger-core/src/main/scala/FileParser.scala
+++ b/avrohugger-core/src/main/scala/FileParser.scala
@@ -23,7 +23,8 @@ class FileParser {
       case "avdl" =>
         val idlParser = new Idl(infile)
         val protocol = idlParser.CompilationUnit()
-        protocol.getTypes.asScala.toList
+        val types = protocol.getTypes
+        types.asScala.toList
       case _ => throw new Exception("File must end in .avsc for plain text json files, .avdl for IDL files, or .avro for binary.")
     }
     schemas.map(s => s.getType match {

--- a/avrohugger-core/src/main/scala/format/DependencyInspectionSupport.scala
+++ b/avrohugger-core/src/main/scala/format/DependencyInspectionSupport.scala
@@ -1,0 +1,41 @@
+package avrohugger
+package format
+
+import org.apache.avro.Schema
+import org.apache.avro.Schema.Field
+
+import scala.collection.JavaConversions._
+
+
+object DependencyInspectionSupport {
+  import Schema.Type._
+  def getSchemaReferredNamespace(schema: Schema): Option[String] = schema.getType match {
+    case ARRAY =>
+      getSchemaReferredNamespace(schema.getElementType)
+    case UNION =>
+      schema.getTypes.find( innerType => innerType.getType != NULL ) flatMap getSchemaReferredNamespace
+    case MAP =>
+      getSchemaReferredNamespace(schema.getValueType)
+    case RECORD =>
+      Option(schema.getNamespace)
+    case _ => None
+
+  }
+
+
+  def getFieldReferredNamespace(field: Field): Option[String] = getSchemaReferredNamespace(field.schema)
+
+  def getReferredTypeName(schema: Schema): String = schema.getType match {
+    case ARRAY =>
+      schema.getElementType.getName
+    case UNION =>
+      schema.getTypes.find( innerType => innerType.getType != NULL ).map( _.getName ).getOrElse("")
+    case MAP =>
+      schema.getValueType.getName
+    case _ =>
+      schema.getName
+  }
+
+  def getReferredTypeName(field: Field): String = getReferredTypeName(field.schema)
+
+}

--- a/avrohugger-core/src/main/scala/format/specific/SpecificScalaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/specific/SpecificScalaTreehugger.scala
@@ -2,6 +2,7 @@ package avrohugger
 package format
 package specific
 
+import avrohugger.format.DependencyInspectionSupport._
 import org.apache.avro.Schema.Field
 import trees._
 
@@ -30,12 +31,12 @@ object SpecificScalaTreehugger {
     val imports =
       schema
         .getFields.toList
-        .filter( getFieldNamespace(_).isDefined )
-        .filter { field => getFieldNamespace(field) != namespace }
+        .filter( getFieldReferredNamespace(_).isDefined )
+        .filter { field => getFieldReferredNamespace(field) != namespace }
         .distinct
-        .groupBy( getFieldNamespace(_).get )
+        .groupBy( getFieldReferredNamespace(_).get )
         .map { _ match { case(packageName, fields) =>
-            IMPORT(packageName, fields.map( _.schema.getName ) )
+            IMPORT(packageName, fields.map( getReferredTypeName ) )
           }
         }
 
@@ -56,7 +57,7 @@ object SpecificScalaTreehugger {
     codeString
   }
 
-  def getFieldNamespace(field: Field): Option[String] = {
-    scala.util.Try(Option(field.schema.getNamespace)).getOrElse(None)
-  }
+
 }
+
+

--- a/avrohugger-core/src/main/scala/format/standard/StandardTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardTreehugger.scala
@@ -2,6 +2,7 @@ package avrohugger
 package format
 package standard
 
+import avrohugger.format.DependencyInspectionSupport._
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
 import org.apache.avro.Schema.Type.{ENUM, RECORD}
@@ -45,17 +46,13 @@ object StandardTreehugger {
   def getImports(schema: Schema, currentNamespace: Option[String]): Iterable[Import] = {
     schema
       .getFields.toList
-      .filter( getFieldNamespace(_).isDefined )
-      .filter { field => getFieldNamespace(field) != currentNamespace }
+      .filter( getFieldReferredNamespace(_).isDefined )
+      .filter { field => getFieldReferredNamespace(field) != currentNamespace }
       .distinct
-      .groupBy( getFieldNamespace(_).get )
+      .groupBy( getFieldReferredNamespace(_).get )
       .map { _ match { case(packageName, fields) =>
-        IMPORT(packageName, fields.map( _.schema.getName ) )
+        IMPORT(packageName, fields.map( getReferredTypeName ) )
       }
     }
-  }
-  
-  def getFieldNamespace(field: Field): Option[String] = {
-    scala.util.Try(Option(field.schema.getNamespace)).getOrElse(None)
   }
 }

--- a/avrohugger-core/src/test/avro/import-nested.avdl
+++ b/avrohugger-core/src/test/avro/import-nested.avdl
@@ -1,0 +1,10 @@
+@namespace("example.idl")
+
+protocol ImportProtocol {
+  import idl "imported.avdl";
+
+  record DependentRecord {
+    union {null, other.ns.ExternalDependency} dependency; // refers to the record defined in imported.avdl
+    int number;
+  }
+}

--- a/avrohugger-core/src/test/avro/import.avdl
+++ b/avrohugger-core/src/test/avro/import.avdl
@@ -1,0 +1,10 @@
+@namespace("example.idl")
+
+protocol ImportProtocol {
+  import idl "imported.avdl";
+
+  record DependentRecord {
+    other.ns.ExternalDependency dependency; // refers to the record defined in imported.avdl
+    int number;
+  }
+}

--- a/avrohugger-core/src/test/avro/imported.avdl
+++ b/avrohugger-core/src/test/avro/imported.avdl
@@ -1,0 +1,8 @@
+@namespace("other.ns")
+
+protocol ImportedProtocol {
+
+  record ExternalDependency {
+    int number;
+  }
+}

--- a/avrohugger-core/src/test/scala/avrohugger/format/NamespaceExtractorSpec.scala
+++ b/avrohugger-core/src/test/scala/avrohugger/format/NamespaceExtractorSpec.scala
@@ -1,0 +1,74 @@
+package avrohugger.format
+
+import avrohugger.format.DependencyInspectionSupport.getFieldReferredNamespace
+import org.apache.avro.Schema
+import org.specs2.mutable.Specification
+
+class NamespaceExtractorSpec extends Specification {
+
+  private val schemaDef = """
+                         | {
+                         |  "namespace": "owner.namespace",
+                         |  "type": "record",
+                         |  "name": "ExternalRecord",
+                         |  "fields": [
+                         |    {"name": "stringField", "type": "string"},
+                         |    {"name": "intField", "type": "int"},
+                         |    {"name": "recordNoNamespaceField", "type":
+                         |      {"type": "record",
+                         |       "name": "AddressRecord1",
+                         |       "fields": [ {"name": "streetaddress", "type": "string"} ]
+                         |      }
+                         |    },
+                         |    {"name": "recordWithNamespaceField", "type":
+                         |      {"type": "record",
+                         |       "name": "AddressRecord2",
+                         |       "namespace": "other.namespace",
+                         |       "fields": [ {"name": "streetaddress", "type": "string"} ]
+                         |      }
+                         |    },
+                         |    {"name": "unionOfrecordWithNamespaceField", "type":
+                         |      [
+                         |       "null",
+                         |       { "type": "record",
+                         |        "name": "AddressRecord3",
+                         |        "namespace": "yet.another.namespace",
+                         |        "fields": [ {"name": "streetaddress", "type": "string"} ]
+                         |       }
+                         |     ]
+                         |    },
+                         |    {"name": "arrayOfrecordWithNamespaceField", "type": { "type": "array", "items":
+                         |       { "type": "record",
+                         |        "name": "AddressRecord4",
+                         |        "namespace": "and.yet.another.namespace",
+                         |        "fields": [ {"name": "streetaddress", "type": "string"} ]
+                         |       }
+                         |     }
+                         |    }
+                         |  ]
+                         |}
+                       """.stripMargin
+
+  lazy val ownerSchema = (new Schema.Parser()).parse(schemaDef)
+
+  "A NamespaceExtractor" should {
+
+    "Return no namespace for basic types" in {
+      getFieldReferredNamespace( ownerSchema.getField("stringField") ) === None
+    }
+
+    "Return the namespace of the non null inner type for union types" in {
+      getFieldReferredNamespace( ownerSchema.getField("unionOfrecordWithNamespaceField") ) === Some("yet.another.namespace")
+    }
+
+    "Return the namespace for record types" in {
+      getFieldReferredNamespace( ownerSchema.getField("recordWithNamespaceField") ) === Some("other.namespace")
+    }
+
+    "Return the namespace for array types" in {
+      getFieldReferredNamespace( ownerSchema.getField("arrayOfrecordWithNamespaceField") ) === Some("and.yet.another.namespace")
+    }
+
+  }
+
+}

--- a/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
@@ -173,7 +173,19 @@ class StandardGeneratorSpec extends mutable.Specification {
   }
 
   "correctly generate records depending on others defined in a different AVDL file" in {
-    todo
+    val importing = new java.io.File("avrohugger-core/src/test/avro/import.avdl")
+    val gen = new Generator(Standard)
+    gen.fileToFile(importing)
+
+    val sourceEnum = scala.io.Source.fromFile("target/generated-sources/example/idl/DependentRecord.scala").mkString
+    sourceEnum ====
+      """/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+        |package example.idl
+        |
+        |import other.ns.ExternalDependency
+        |
+        |case class DependentRecord(dependency: ExternalDependency, number: Int)
+        |""".stripMargin.trim
   }
 
   "not generate copy of imported classes in the importing package" in {

--- a/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
@@ -188,6 +188,22 @@ class StandardGeneratorSpec extends mutable.Specification {
         |""".stripMargin.trim
   }
 
+  "correctly generate records depending on others defined in a different AVDL file and in a nested field" in {
+    val importing = new java.io.File("avrohugger-core/src/test/avro/import-nested.avdl")
+    val gen = new Generator(Standard)
+    gen.fileToFile(importing)
+
+    val sourceEnum = scala.io.Source.fromFile("target/generated-sources/example/idl/DependentRecord.scala").mkString
+    sourceEnum ====
+      """/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+        |package example.idl
+        |
+        |import other.ns.ExternalDependency
+        |
+        |case class DependentRecord(dependency: Option[ExternalDependency], number: Int)
+        |""".stripMargin.trim
+  }
+
   "not generate copy of imported classes in the importing package" in {
     val importing = new java.io.File("avrohugger-core/src/test/avro/import.avdl")
     val gen = new Generator(Standard)

--- a/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
@@ -1,6 +1,8 @@
 
+import java.io.File
+
 import avrohugger._
-import format.Standard
+import avrohugger.format.Standard
 import org.specs2._
 
 class StandardGeneratorSpec extends mutable.Specification {
@@ -168,5 +170,25 @@ class StandardGeneratorSpec extends mutable.Specification {
         |
         |case class Card(suit: Suit, number: Int)
       """.stripMargin.trim
+  }
+
+  "correctly generate records depending on others defined in a different AVDL file" in {
+    todo
+  }
+
+  "not generate copy of imported classes in the importing package" in {
+    val importing = new java.io.File("avrohugger-core/src/test/avro/import.avdl")
+    val gen = new Generator(Standard)
+    gen.fileToFile(importing)
+
+    (new File(s"target/generated-sources/example/idl/ExternalDependency.scala")).exists === false
+  }
+
+  "Generate imported classes in the declared package" in {
+    val importing = new java.io.File("avrohugger-core/src/test/avro/import.avdl")
+    val gen = new Generator(Standard)
+    gen.fileToFile(importing)
+
+    (new File(s"target/generated-sources/other/ns/ExternalDependency.scala")).exists === true
   }
 }


### PR DESCRIPTION
Hi,

I'm using the sbt-avrohugger plugin to generate scala code in one of my project and I want to use schemas from different namespaces sharing types. The plugin works fine but in this special case it is generating duplicated classes. It also is causing the classes to be used in the importing type to be the one in the same namespace in the code but not when the type is deserialised.

I'm attaching a proposed solution for the problem 
