### PR TITLE
Add support for recursive schemas

### DIFF
--- a/avrohugger-core/src/main/scala/input/NestedSchemaExtractor.scala
+++ b/avrohugger-core/src/main/scala/input/NestedSchemaExtractor.scala
@@ -11,7 +11,7 @@ object NestedSchemaExtractor {
   // if a record is found, extract nested RECORDs and ENUMS (i.e. top-level types) 
   def getNestedSchemas(schema: Schema): List[Schema] = {
 
-    def extract(schema: Schema): List[Schema] = {
+    def extract(schema: Schema, fieldPath: List[String] = List.empty): List[Schema] = {
     schema.getType match {
 
       case RECORD =>
@@ -24,7 +24,9 @@ object NestedSchemaExtractor {
             case RECORD => {
               // if the field schema is one that has already been stored, use that one
               if (SchemaStore.schemas.contains(fieldSchema.getFullName)) List()
-              else fieldSchema :: extract(fieldSchema)
+              // if we've already seen this schema (recursive schemas) don't traverse further
+              else if (fieldPath.contains(fieldSchema.getFullName)) List()
+              else fieldSchema :: extract(fieldSchema, fieldSchema.getFullName :: fieldPath)
             }
             case UNION => fieldSchema.getTypes.asScala.toList.flatMap(x => flattenSchema(x))
             case ENUM => { //List(fieldSchema)

--- a/avrohugger-core/src/test/avro/recursive.avdl
+++ b/avrohugger-core/src/test/avro/recursive.avdl
@@ -1,0 +1,8 @@
+@namespace("example.idl")
+protocol RecursiveProtocol {
+
+  record Recursive {
+    string name;
+    union {null, Recursive} recursive;
+  }
+}

--- a/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardGeneratorSpec.scala
@@ -217,6 +217,22 @@ class StandardGeneratorSpec extends mutable.Specification {
       """.stripMargin.trim
   }
 
+
+  "correctly generate a recursive case class from IDL" in {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/recursive.avdl")
+    val gen = new Generator(Standard)
+    gen.fileToFile(infile)
+
+    val source = scala.io.Source.fromFile("target/generated-sources/example/idl/Recursive.scala").mkString
+    source ====
+      """
+        |/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+        |package example.idl
+        |
+        |case class Recursive(name: String, recursive: Option[Recursive])
+      """.stripMargin.trim
+  }
+
   "correctly generate enums" in {
     val infile = new java.io.File("avrohugger-core/src/test/avro/enums.avsc")
     val gen = new Generator(Standard)


### PR DESCRIPTION
Not sure if I should add caveats, but worth mentioning, I think in general, recursive avro schemas should be avoided because it can cause compatibility issues if trying to flow data into a system that doesn't support (eg, hive).
