### PR TITLE
Option to generate classes instead of case classes when fields.size > 22

### DIFF
--- a/avrohugger-core/src/main/scala/FileGenerator.scala
+++ b/avrohugger-core/src/main/scala/FileGenerator.scala
@@ -24,27 +24,29 @@ private[avrohugger] object FileGenerator {
     format: SourceFormat,
     classStore: ClassStore,
     schemaStore: SchemaStore,
-    typeMatcher: TypeMatcher): Unit = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): Unit = {
     val topNS: Option[String] = DependencyInspector.getReferredNamespace(schema)
-    val topLevelSchemas: List[Schema] = 
+    val topLevelSchemas: List[Schema] =
       NestedSchemaExtractor.getNestedSchemas(schema, schemaStore)
     // most-nested classes processed first
     topLevelSchemas.reverse.distinct.foreach(schema => {
       // pass in the top-level schema's namespace if the nested schema has none
       val ns = DependencyInspector.getReferredNamespace(schema) orElse topNS
-      format.compile(classStore, ns, Left(schema), outDir, schemaStore, typeMatcher)
+      format.compile(classStore, ns, Left(schema), outDir, schemaStore, typeMatcher, restrictedFields)
     })
   }
-  
+
   def protocolToFile(
     protocol: Protocol,
     outDir: String,
     format: SourceFormat,
     classStore: ClassStore,
     schemaStore: SchemaStore,
-    typeMatcher: TypeMatcher): Unit = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): Unit = {
     val ns = Option(protocol.getNamespace)
-    format.compile(classStore, ns, Right(protocol), outDir, schemaStore, typeMatcher)
+    format.compile(classStore, ns, Right(protocol), outDir, schemaStore, typeMatcher, restrictedFields)
   }
 
   def stringToFile(
@@ -54,15 +56,16 @@ private[avrohugger] object FileGenerator {
     classStore: ClassStore,
     schemaStore: SchemaStore,
     stringParser: StringInputParser,
-    typeMatcher: TypeMatcher): Unit = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): Unit = {
     val schemaOrProtocols = stringParser.getSchemaOrProtocols(str, schemaStore)
     schemaOrProtocols.foreach(schemaOrProtocol => {
       schemaOrProtocol match {
         case Left(schema) => {
-          schemaToFile(schema, outDir, format, classStore, schemaStore, typeMatcher)
+          schemaToFile(schema, outDir, format, classStore, schemaStore, typeMatcher, restrictedFields)
         }
         case Right(protocol) => {
-          protocolToFile(protocol, outDir, format, classStore, schemaStore, typeMatcher)
+          protocolToFile(protocol, outDir, format, classStore, schemaStore, typeMatcher, restrictedFields)
         }
       }
     })
@@ -75,15 +78,16 @@ private[avrohugger] object FileGenerator {
     classStore: ClassStore,
     schemaStore: SchemaStore,
     fileParser: FileInputParser,
-    typeMatcher: TypeMatcher): Unit = {      
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): Unit = {
     val schemaOrProtocols: List[Either[Schema, Protocol]] =
       fileParser.getSchemaOrProtocols(inFile, format, classStore)
     schemaOrProtocols.foreach(schemaOrProtocol => schemaOrProtocol match {
       case Left(schema) => {
-        schemaToFile(schema, outDir, format, classStore, schemaStore, typeMatcher)
+        schemaToFile(schema, outDir, format, classStore, schemaStore, typeMatcher, restrictedFields)
       }
       case Right(protocol) => {
-        protocolToFile(protocol, outDir, format, classStore, schemaStore, typeMatcher)
+        protocolToFile(protocol, outDir, format, classStore, schemaStore, typeMatcher, restrictedFields)
       }
     })
   }

--- a/avrohugger-core/src/main/scala/Generator.scala
+++ b/avrohugger-core/src/main/scala/Generator.scala
@@ -42,16 +42,14 @@ class Generator(format: SourceFormat,
   //////////////// methods for writing definitions out to file /////////////////
   def schemaToFile(
     schema: Schema,
-    outDir: String = defaultOutputDir,
-    restrictedFields: Boolean = false): Unit = {
+    outDir: String = defaultOutputDir): Unit = {
     FileGenerator.schemaToFile(
-      schema, outDir, format, classStore, schemaStore, typeMatcher, restrictedFields)
+      schema, outDir, format, classStore, schemaStore, typeMatcher, restrictedFieldNumber)
   }
 
   def protocolToFile(
     protocol: Protocol,
-    outDir: String = defaultOutputDir/*,
-    restrictedFields: Boolean = false*/): Unit = {
+    outDir: String = defaultOutputDir): Unit = {
     FileGenerator.protocolToFile(
       protocol,
       outDir,
@@ -64,8 +62,7 @@ class Generator(format: SourceFormat,
 
   def stringToFile(
     schemaStr: String,
-    outDir: String = defaultOutputDir/*,
-    restrictedFields: Boolean = false*/): Unit = {
+    outDir: String = defaultOutputDir): Unit = {
     FileGenerator.stringToFile(
       schemaStr,
       outDir,
@@ -79,8 +76,7 @@ class Generator(format: SourceFormat,
 
   def fileToFile(
     inFile: File,
-    outDir: String = defaultOutputDir/*,
-    restrictedFields: Boolean = false*/): Unit = {
+    outDir: String = defaultOutputDir): Unit = {
     FileGenerator.fileToFile(
       inFile,
       outDir,

--- a/avrohugger-core/src/main/scala/Generator.scala
+++ b/avrohugger-core/src/main/scala/Generator.scala
@@ -12,10 +12,11 @@ import java.io.File
 
 // Unable to overload this class' methods because outDir uses a default value
 class Generator(format: SourceFormat,
-  avroScalaCustomTypes: Map[String, Class[_]] = Map.empty,
-  avroScalaCustomNamespace: Map[String, String] = Map.empty,
-  avroScalaCustomEnumStyle: Map[String, String] = Map.empty) {
-  
+                avroScalaCustomTypes: Map[String, Class[_]] = Map.empty,
+                avroScalaCustomNamespace: Map[String, String] = Map.empty,
+                avroScalaCustomEnumStyle: Map[String, String] = Map.empty,
+                restrictedFieldNumber: Boolean = false) {
+
   val sourceFormat = format
   val defaultOutputDir = "target/generated-sources"
   lazy val fileParser = new FileInputParser
@@ -24,7 +25,7 @@ class Generator(format: SourceFormat,
   val classStore = new ClassStore
   val schemaStore = new SchemaStore
   val typeMatcher = new TypeMatcher
-  
+
   // update format defaults
   format match {
     case Scavro =>
@@ -41,58 +42,65 @@ class Generator(format: SourceFormat,
   //////////////// methods for writing definitions out to file /////////////////
   def schemaToFile(
     schema: Schema,
-    outDir: String = defaultOutputDir): Unit = {
+    outDir: String = defaultOutputDir,
+    restrictedFields: Boolean = false): Unit = {
     FileGenerator.schemaToFile(
-      schema, outDir, format, classStore, schemaStore, typeMatcher)
+      schema, outDir, format, classStore, schemaStore, typeMatcher, restrictedFields)
   }
-  
+
   def protocolToFile(
     protocol: Protocol,
-    outDir: String = defaultOutputDir): Unit = {
+    outDir: String = defaultOutputDir/*,
+    restrictedFields: Boolean = false*/): Unit = {
     FileGenerator.protocolToFile(
       protocol,
       outDir,
       format,
       classStore,
       schemaStore,
-      typeMatcher)
+      typeMatcher,
+      restrictedFieldNumber)
   }
 
   def stringToFile(
     schemaStr: String,
-    outDir: String = defaultOutputDir): Unit = {
+    outDir: String = defaultOutputDir/*,
+    restrictedFields: Boolean = false*/): Unit = {
     FileGenerator.stringToFile(
       schemaStr,
       outDir,
-      format, 
+      format,
       classStore,
       schemaStore,
       stringParser,
-      typeMatcher)
+      typeMatcher,
+      restrictedFieldNumber)
   }
 
   def fileToFile(
     inFile: File,
-    outDir: String = defaultOutputDir): Unit = {
+    outDir: String = defaultOutputDir/*,
+    restrictedFields: Boolean = false*/): Unit = {
     FileGenerator.fileToFile(
       inFile,
       outDir,
-      format, 
+      format,
       classStore,
       schemaStore,
       fileParser,
-      typeMatcher)
+      typeMatcher,
+      restrictedFieldNumber)
   }
 
   //////// methods for writing to a list of definitions in String format ///////
   def schemaToStrings(schema: Schema): List[String] = {
     StringGenerator.schemaToStrings(
-      schema, format, classStore, schemaStore, typeMatcher)
+      schema, format, classStore, schemaStore, typeMatcher, restrictedFieldNumber)
   }
-  
+
   def protocolToStrings(protocol: Protocol): List[String] = {
     StringGenerator.protocolToStrings(
-      protocol, format, classStore, schemaStore, typeMatcher)
+      protocol, format, classStore, schemaStore, typeMatcher, restrictedFieldNumber)
   }
 
   def stringToStrings(schemaStr: String): List[String] = {
@@ -102,7 +110,8 @@ class Generator(format: SourceFormat,
       classStore,
       schemaStore,
       stringParser,
-      typeMatcher)
+      typeMatcher,
+      restrictedFieldNumber)
   }
 
   def fileToStrings(inFile: File): List[String] = {
@@ -112,7 +121,8 @@ class Generator(format: SourceFormat,
       classStore,
       schemaStore,
       fileParser,
-      typeMatcher)
+      typeMatcher,
+      restrictedFieldNumber)
   }
 
 }

--- a/avrohugger-core/src/main/scala/StringGenerator.scala
+++ b/avrohugger-core/src/main/scala/StringGenerator.scala
@@ -23,7 +23,8 @@ private[avrohugger] object StringGenerator {
     format: SourceFormat,
     classStore: ClassStore,
     schemaStore: SchemaStore,
-    typeMatcher: TypeMatcher): List[String] = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): List[String] = {
     val maybeNamespace = DependencyInspector.getReferredNamespace(schema)
     val topLevels = NestedSchemaExtractor.getNestedSchemas(schema, schemaStore)
     //reversed to process nested classes first
@@ -38,17 +39,19 @@ private[avrohugger] object StringGenerator {
         Left(schema),
         schemaStore,
         None,
-        typeMatcher)
+        typeMatcher,
+        restrictedFields)
     })
     compilationUnits.map(compUnit => removeExtraWarning(compUnit.codeString))
   }
-  
+
   def protocolToStrings(
     protocol: Protocol,
     format: SourceFormat,
     classStore: ClassStore,
     schemaStore: SchemaStore,
-    typeMatcher: TypeMatcher): List[String] = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): List[String] = {
     val namespace: Option[String] = Option(protocol.getNamespace)
     val compilationUnits = format.asCompilationUnits(
       classStore,
@@ -56,7 +59,8 @@ private[avrohugger] object StringGenerator {
       Right(protocol),
       schemaStore,
       None,
-      typeMatcher)
+      typeMatcher,
+      restrictedFields)
     compilationUnits.map(compUnit => removeExtraWarning(compUnit.codeString))
   }
 
@@ -66,15 +70,16 @@ private[avrohugger] object StringGenerator {
     classStore: ClassStore,
     schemaStore: SchemaStore,
     stringParser: StringInputParser,
-    typeMatcher: TypeMatcher): List[String] = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): List[String] = {
     val schemaOrProtocols = stringParser.getSchemaOrProtocols(str, schemaStore)
     val codeStrings = schemaOrProtocols.flatMap(schemaOrProtocol => {
       schemaOrProtocol match {
         case Left(schema) => {
-          schemaToStrings(schema, format, classStore, schemaStore, typeMatcher)
+          schemaToStrings(schema, format, classStore, schemaStore, typeMatcher, restrictedFields)
         }
         case Right(protocol) => {
-          protocolToStrings(protocol, format, classStore, schemaStore, typeMatcher)
+          protocolToStrings(protocol, format, classStore, schemaStore, typeMatcher, restrictedFields)
         }
       }
     }).distinct
@@ -89,16 +94,17 @@ private[avrohugger] object StringGenerator {
     classStore: ClassStore,
     schemaStore: SchemaStore,
     fileParser: FileInputParser,
-    typeMatcher: TypeMatcher): List[String] = {
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): List[String] = {
     try {
       val schemaOrProtocols: List[Either[Schema, Protocol]] =
         fileParser.getSchemaOrProtocols(inFile, format, classStore)
       schemaOrProtocols.flatMap(schemaOrProtocol => schemaOrProtocol match {
         case Left(schema) => {
-          schemaToStrings(schema, format, classStore, schemaStore, typeMatcher)
+          schemaToStrings(schema, format, classStore, schemaStore, typeMatcher, restrictedFields)
         }
         case Right(protocol) => {
-          protocolToStrings(protocol, format, classStore, schemaStore, typeMatcher)
+          protocolToStrings(protocol, format, classStore, schemaStore, typeMatcher, restrictedFields)
         }
       })
     }

--- a/avrohugger-core/src/main/scala/format/abstractions/ScalaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/ScalaTreehugger.scala
@@ -20,20 +20,21 @@ import treehugger.forest.Tree
   */
 trait ScalaTreehugger {
 
-  ///////////////////////////// abstract members ///////////////////////////////  
+  ///////////////////////////// abstract members ///////////////////////////////
   def asScalaCodeString(
     classStore: ClassStore,
     namespace: Option[String],
     schemaOrProtocol: Either[Schema, Protocol],
     typeMatcher: TypeMatcher,
-    schemaStore: SchemaStore): String
+    schemaStore: SchemaStore,
+    restrictedFields: Boolean): String
 
   val importer: Importer
 
   val protocolhugger: Protocolhugger
 
   val schemahugger: Schemahugger
-      
 
-  
+
+
 }

--- a/avrohugger-core/src/main/scala/format/abstractions/avrohuggers/Protocolhugger.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/avrohuggers/Protocolhugger.scala
@@ -13,24 +13,25 @@ import treehugger.forest.Tree
 import scala.collection.JavaConversions._
 
 trait Protocolhugger {
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     protocol: Protocol,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree]
-    
-    
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree]
+
+
   def getLocalSubtypes(protocol: Protocol): List[Schema] = {
     val protocolNS = protocol.getNamespace
     val types = protocol.getTypes.toList
     def isTopLevelNamespace(schema: Schema) = schema.getNamespace == protocolNS
     types.filter(isTopLevelNamespace)
   }
-  
+
   def isEnum(schema: Schema) = schema.getType == Schema.Type.ENUM
 
-    
+
 }

--- a/avrohugger-core/src/main/scala/format/abstractions/avrohuggers/Schemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/avrohuggers/Schemahugger.scala
@@ -11,13 +11,14 @@ import org.apache.avro.Schema
 import treehugger.forest.Tree
 
 trait Schemahugger {
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     schema: Schema,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree]
-    
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree]
+
 }

--- a/avrohugger-core/src/main/scala/format/scavro/ScavroScalaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroScalaTreehugger.scala
@@ -17,7 +17,7 @@ import treehuggerDSL._
 import scala.collection.JavaConversions._
 
 object ScavroScalaTreehugger extends ScalaTreehugger {
-  
+
   val schemahugger = ScavroSchemahugger
   val protocolhugger = ScavroProtocolhugger
 	val importer = ScavroImporter
@@ -29,7 +29,8 @@ object ScavroScalaTreehugger extends ScalaTreehugger {
     namespace: Option[String],
     schemaOrProtocol: Either[Schema, Protocol],
     typeMatcher: TypeMatcher,
-    schemaStore: SchemaStore): String = {
+    schemaStore: SchemaStore,
+    restrictedFields: Boolean): String = {
 
     val imports: List[Import] = importer.getImports(
       schemaOrProtocol, namespace, schemaStore, typeMatcher)
@@ -41,7 +42,8 @@ object ScavroScalaTreehugger extends ScalaTreehugger {
         schema,
         typeMatcher,
         None,
-        None
+        None,
+        restrictedFields
       )
       case Right(protocol) => protocolhugger.toTrees(
         classStore,
@@ -49,7 +51,8 @@ object ScavroScalaTreehugger extends ScalaTreehugger {
         protocol,
         typeMatcher,
         None,
-        None
+        None,
+        restrictedFields
       )
     }
     // wrap the imports and classdef in a block with a comment and a package
@@ -58,8 +61,8 @@ object ScavroScalaTreehugger extends ScalaTreehugger {
       if (namespace.isDefined) BLOCK(blockContent).inPackage(namespace.get)
       else BLOCK(blockContent:_*).withoutPackage
     }.withDoc("MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY")
-    
+
     treeToString(tree)
   }
-  
+
 }

--- a/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroProtocolhugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroProtocolhugger.scala
@@ -17,15 +17,16 @@ import treehuggerDSL._
 import scala.collection.JavaConversions._
 
 object ScavroProtocolhugger extends Protocolhugger {
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     protocol: Protocol,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree] = {
-      
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree] = {
+
     val name: String = protocol.getName
     val maybeNewBaseTrait = Some(name)
     val maybeNewFlags = Some(List(Flags.FINAL.toLong))
@@ -43,7 +44,8 @@ object ScavroProtocolhugger extends Protocolhugger {
           schema,
           typeMatcher,
           maybeNewBaseTrait,
-          maybeNewFlags)
+          maybeNewFlags,
+          restrictedFields)
       })
     }
     // if only one Scala type is defined, then don't generate sealed trait
@@ -51,10 +53,10 @@ object ScavroProtocolhugger extends Protocolhugger {
       // no sealed trait tree, but could still need a top-level doc
       val docTrees = {
         Option(protocol.getDoc) match {
-          case Some(doc) => 
+          case Some(doc) =>
             List(ScalaDocGenerator.docToScalaDoc(Right(protocol), EmptyTree))
           case None => List.empty
-        }	
+        }
       }
       docTrees ::: adtSubTypes.flatMap(schema => {
         ScavroSchemahugger.toTrees(
@@ -63,9 +65,10 @@ object ScavroProtocolhugger extends Protocolhugger {
           schema,
           typeMatcher,
           maybeBaseTrait,
-          maybeFlags)
+          maybeFlags,
+          restrictedFields)
       })
     }
   }
-  
+
 }

--- a/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroSchemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroSchemahugger.scala
@@ -16,14 +16,15 @@ import definitions._
 import treehuggerDSL._
 
 object ScavroSchemahugger extends Schemahugger{
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     schema: Schema,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree] = {
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree] = {
     val ScalaClass = RootClass.newClass(schema.getName)
     val JavaClass = RootClass.newClass("J" + schema.getName)
     schema.getType match {
@@ -36,7 +37,8 @@ object ScavroSchemahugger extends Schemahugger{
           JavaClass,
           typeMatcher,
           maybeBaseTrait,
-          maybeFlags)
+          maybeFlags,
+          restrictedFields)
         val companionDef = ScavroObjectTree.toCompanionDef(
           classStore,
           schema,
@@ -62,5 +64,5 @@ object ScavroSchemahugger extends Schemahugger{
         sys.error("Only RECORD and ENUM can be top-level definitions")
     }
   }
-  
+
 }

--- a/avrohugger-core/src/main/scala/format/specific/SpecificScalaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/specific/SpecificScalaTreehugger.scala
@@ -18,19 +18,20 @@ import treehuggerDSL._
 import scala.collection.JavaConversions._
 
 object SpecificScalaTreehugger extends ScalaTreehugger {
-  
+
   val schemahugger = SpecificSchemahugger
   val protocolhugger = SpecificProtocolhugger
   val importer = SpecificImporter
-  
+
   // SpecificCompiler can't return a tree for Java enums, so return
   // a String here for a consistent api vis a vis *ToFile and *ToStrings
   def asScalaCodeString(
-    classStore: ClassStore, 
-    namespace: Option[String], 
+    classStore: ClassStore,
+    namespace: Option[String],
     schemaOrProtocol: Either[Schema, Protocol],
     typeMatcher: TypeMatcher,
-    schemaStore: SchemaStore): String = {
+    schemaStore: SchemaStore,
+    restrictedFields: Boolean): String = {
 
     // imports in case a field type is from a different namespace
     val imports: List[Import] = importer.getImports(
@@ -46,7 +47,8 @@ object SpecificScalaTreehugger extends ScalaTreehugger {
         schema,
         typeMatcher,
         None,
-        None
+        None,
+        restrictedFields
       )
       case Right(protocol) => protocolhugger.toTrees(
         classStore,
@@ -54,10 +56,11 @@ object SpecificScalaTreehugger extends ScalaTreehugger {
         protocol,
         typeMatcher,
         None,
-        None
+        None,
+        restrictedFields
       )
     }
-    
+
     // wrap the definitions in a block with a comment and a package
     val tree = {
       val blockContent = imports ++ topLevelDefs

--- a/avrohugger-core/src/main/scala/format/specific/avrohuggers/SpecificSchemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/specific/avrohuggers/SpecificSchemahugger.scala
@@ -13,26 +13,28 @@ import org.apache.avro.Schema
 import treehugger.forest.Tree
 
 object SpecificSchemahugger extends Schemahugger {
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     schema: Schema,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree] = {
-        
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree] = {
+
     val caseClassDef = SpecificCaseClassTree.toCaseClassDef(
       classStore,
       namespace,
       schema,
       typeMatcher,
       maybeBaseTrait,
-      maybeFlags)
-      
+      maybeFlags,
+      restrictedFields)
+
     val companionDef = SpecificObjectTree.toCaseCompanionDef(schema, maybeFlags)
-    
+
     List(caseClassDef, companionDef)
   }
-  
+
 }

--- a/avrohugger-core/src/main/scala/format/standard/StandardScalaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardScalaTreehugger.scala
@@ -18,7 +18,7 @@ import treehuggerDSL._
 import scala.collection.JavaConversions._
 
 object StandardScalaTreehugger extends ScalaTreehugger {
-  
+
   val schemahugger = StandardSchemahugger
   val protocolhugger = StandardProtocolhugger
   val importer = StandardImporter
@@ -26,13 +26,14 @@ object StandardScalaTreehugger extends ScalaTreehugger {
   def asScalaCodeString(
 		classStore: ClassStore,
     namespace: Option[String],
-    schemaOrProtocol: Either[Schema, Protocol], 
+    schemaOrProtocol: Either[Schema, Protocol],
     typeMatcher: TypeMatcher,
-    schemaStore: SchemaStore): String = {
-      
+    schemaStore: SchemaStore,
+    restrictedFields: Boolean): String = {
+
     val imports = importer.getImports(
       schemaOrProtocol, namespace, schemaStore, typeMatcher)
-      
+
     val topLevelDefs: List[Tree] = schemaOrProtocol match {
       case Left(schema) => schemahugger.toTrees(
         classStore,
@@ -40,7 +41,8 @@ object StandardScalaTreehugger extends ScalaTreehugger {
         schema,
         typeMatcher,
         None,
-        None
+        None,
+        restrictedFields
       )
       case Right(protocol) => protocolhugger.toTrees(
         classStore,
@@ -48,10 +50,11 @@ object StandardScalaTreehugger extends ScalaTreehugger {
         protocol,
         typeMatcher,
         None,
-        None
+        None,
+        restrictedFields
       )
     }
-      
+
     // wrap the imports and class definition in a block with comment and package
     val tree = {
       val blockContent = imports ++ topLevelDefs

--- a/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardProtocolhugger.scala
+++ b/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardProtocolhugger.scala
@@ -18,24 +18,25 @@ import format.abstractions.avrohuggers.Protocolhugger
 import scala.collection.JavaConversions._
 
 object StandardProtocolhugger extends Protocolhugger {
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     protocol: Protocol,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree] = {
-      
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree] = {
+
     val name: String = protocol.getName
-    
+
     val localSubTypes = getLocalSubtypes(protocol)
-      
+
     val adtSubTypes = typeMatcher.customEnumStyleMap.get("enum") match {
       case Some("java enum") => localSubTypes.filterNot(isEnum)
       case _ => localSubTypes
     }
-    
+
     if (adtSubTypes.length > 1) {
       val maybeNewBaseTrait = Some(name)
       val maybeNewFlags = Some(List(Flags.FINAL.toLong))
@@ -47,7 +48,8 @@ object StandardProtocolhugger extends Protocolhugger {
           schema,
           typeMatcher,
           maybeNewBaseTrait,
-          maybeNewFlags)
+          maybeNewFlags,
+          restrictedFields)
       })
     }
     // if only one Scala type is defined, then don't generate sealed trait
@@ -55,11 +57,11 @@ object StandardProtocolhugger extends Protocolhugger {
       // no sealed trait tree, but could still need a top-level doc
       val docTrees = {
         Option(protocol.getDoc) match {
-          case Some(doc) => 
+          case Some(doc) =>
             List(ScalaDocGenerator.docToScalaDoc(Right(protocol), EmptyTree))
           case None => List.empty
-        }	
-      } 
+        }
+      }
       docTrees ::: localSubTypes.flatMap(schema => {
         StandardSchemahugger.toTrees(
           classStore,
@@ -67,9 +69,10 @@ object StandardProtocolhugger extends Protocolhugger {
           schema,
           typeMatcher,
           maybeBaseTrait,
-          maybeFlags)
+          maybeFlags,
+          restrictedFields)
       })
     }
   }
-  
+
 }

--- a/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardSchemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardSchemahugger.scala
@@ -16,24 +16,26 @@ import definitions._
 import treehuggerDSL._
 
 object StandardSchemahugger extends Schemahugger {
-  
+
   def toTrees(
     classStore: ClassStore,
     namespace: Option[String],
     schema: Schema,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]): List[Tree] = { // as case class definition
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean): List[Tree] = { // as case class definition
 
     schema.getType match {
-      case RECORD => 
+      case RECORD =>
         val classDef = StandardCaseClassTree.toCaseClassDef(
           classStore,
           namespace,
           schema,
           typeMatcher,
           maybeBaseTrait,
-          maybeFlags)
+          maybeFlags,
+          restrictedFields)
         List(classDef)
       case ENUM => typeMatcher.customEnumStyleMap.get("enum") match {
         case Some("java enum") =>
@@ -51,5 +53,5 @@ object StandardSchemahugger extends Schemahugger {
       case _ => sys.error("Only RECORD or ENUM can be toplevel definitions")
     }
   }
-  
+
 }

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -97,7 +97,7 @@ object StandardCaseClassTree {
       }
       case (None, None) => {
         if (shouldGenerateSimpleClass) {
-          CASECLASSDEF(classSymbol)
+          CLASSDEF(classSymbol)
             .withParams(params)
         }
         else if (!avroFields.isEmpty) {

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -18,27 +18,37 @@ import scala.collection.JavaConversions._
 object StandardCaseClassTree {
 
   def toCaseClassDef(
-    classStore: ClassStore, 
-    namespace: Option[String], 
+    classStore: ClassStore,
+    namespace: Option[String],
     schema: Schema,
     typeMatcher: TypeMatcher,
     maybeBaseTrait: Option[String],
-    maybeFlags: Option[List[Long]]) = {
-      
+    maybeFlags: Option[List[Long]],
+    restrictedFields: Boolean) = {
+
     // register new type
     val classSymbol = RootClass.newClass(schema.getName)
-    
-    val params: List[ValDef] = schema.getFields.toList.map(f => {
+    val avroFields = schema.getFields.toList
+
+    val shouldGenerateSimpleClass = restrictedFields && avroFields.size > 22
+
+    val params: List[ValDef] = avroFields.map(f => {
       val fieldName = f.name
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
       val defaultValue = DefaultValueMatcher.getDefaultValue(f, typeMatcher)
       PARAM(fieldName, fieldType) := defaultValue
     })
-    
+
     // There could be base traits, flags, or both, and could have no fields
     val caseClassDef = (maybeBaseTrait, maybeFlags) match {
       case (Some(baseTrait), Some(flags)) => {
-        if (!schema.getFields.toList.isEmpty) {
+        if (shouldGenerateSimpleClass) {
+          CLASSDEF(classSymbol)
+            .withFlags(flags:_*)
+            .withParams(params)
+            .withParents(baseTrait)
+        }
+        else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)
             .withFlags(flags:_*)
             .withParams(params)
@@ -52,7 +62,12 @@ object StandardCaseClassTree {
         }
       }
       case (Some(baseTrait), None) => {
-        if (!schema.getFields.toList.isEmpty) {
+        if (shouldGenerateSimpleClass) {
+          CLASSDEF(classSymbol)
+            .withParams(params)
+            .withParents(baseTrait)
+        }
+        else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)
             .withParams(params)
             .withParents(baseTrait)
@@ -64,7 +79,12 @@ object StandardCaseClassTree {
         }
       }
       case (None, Some(flags)) => {
-        if (!schema.getFields.toList.isEmpty) {
+        if (shouldGenerateSimpleClass) {
+          CLASSDEF(classSymbol)
+            .withFlags(flags:_*)
+            .withParams(params)
+        }
+        else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)
             .withFlags(flags:_*)
             .withParams(params)
@@ -76,7 +96,11 @@ object StandardCaseClassTree {
         }
       }
       case (None, None) => {
-        if (!schema.getFields.toList.isEmpty) {
+        if (shouldGenerateSimpleClass) {
+          CASECLASSDEF(classSymbol)
+            .withParams(params)
+        }
+        else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)
             .withParams(params)
         }
@@ -86,14 +110,14 @@ object StandardCaseClassTree {
         }
       }
     }
-    
+
     val classTree = caseClassDef.tree
 
 
     val treeWithScalaDoc = ScalaDocGenerator.docToScalaDoc(
       Left(schema),
       classTree)
-      
+
     treeWithScalaDoc
   }
 

--- a/avrohugger-core/src/test/avro/ManyFields.avdl
+++ b/avrohugger-core/src/test/avro/ManyFields.avdl
@@ -1,0 +1,40 @@
+@namespace("test.avdl")
+protocol ManyFieldsProtocol {
+
+  enum SomeEnum {
+    yes, no, maybe
+  }
+
+  /** Used to test Scala 2.10 support */
+  record ManyFields {
+    string field01;
+    int field02;
+    double field03;
+    union {null, string} field04;
+    union {null, int} field05;
+    union {null, double} field06;
+    long field07;
+    string field08;
+    SomeEnum field09;
+    string field10;
+    string field11;
+    string field12;
+    string field13;
+    string field14;
+    int field15;
+    double field16;
+    string field17;
+    int field18;
+    double field19;
+    string fiel20;
+    int field21;
+    string field22;
+    string field23;
+    double field24;
+    string field25;
+    double field26;
+    string field27;
+    double field28;
+    string field29;
+  }
+}

--- a/avrohugger-core/src/test/avro/ManyFields.avsc
+++ b/avrohugger-core/src/test/avro/ManyFields.avsc
@@ -1,0 +1,101 @@
+{
+  "protocol" : "ManyFieldsProtocol",
+  "namespace" : "test.avsc",
+  "type" : "record",
+  "name" : "ManyFields",
+  "doc" : "Used to test Scala 2.10 support",
+  "fields" : [ {
+    "name" : "field01",
+    "type" : "string"
+    }, {
+      "name" : "field02",
+      "type" : "int"
+    }, {
+      "name" : "field03",
+      "type" : "double"
+    }, {
+      "name" : "field04",
+      "type" : [ "null", "string" ]
+    }, {
+      "name" : "field05",
+      "type" : [ "null", "int" ]
+    }, {
+      "name" : "field06",
+      "type" : [ "null", "double" ]
+    }, {
+      "name" : "field07",
+      "type" : "long"
+    }, {
+      "name" : "field08",
+      "type" : "string"
+    }, {
+      "name" : "field09",
+      "type" : {
+        "type" : "enum",
+        "name" : "SomeEnum",
+        "symbols" : [ "yes", "no", "maybe" ]
+       }
+    }, {
+      "name" : "field10",
+      "type" : "string"
+    }, {
+      "name" : "field11",
+      "type" : "string"
+    }, {
+      "name" : "field12",
+      "type" : "string"
+    }, {
+      "name" : "field13",
+      "type" : "string"
+    }, {
+      "name" : "field14",
+      "type" : "string"
+    }, {
+      "name" : "field15",
+      "type" : "int"
+    }, {
+      "name" : "field16",
+      "type" : "double"
+    }, {
+      "name" : "field17",
+      "type" : "string"
+    }, {
+      "name" : "field18",
+      "type" : "int"
+    }, {
+      "name" : "field19",
+      "type" : "double"
+    }, {
+      "name" : "fiel20",
+      "type" : "string"
+    }, {
+      "name" : "field21",
+      "type" : "int"
+    }, {
+      "name" : "field22",
+      "type" : "string"
+    }, {
+      "name" : "field23",
+      "type" : "string"
+    }, {
+      "name" : "field24",
+      "type" : "double"
+    }, {
+      "name" : "field25",
+      "type" : "string"
+    }, {
+      "name" : "field26",
+      "type" : "double"
+    }, {
+      "name" : "field27",
+      "type" : "string"
+    }, {
+      "name" : "field28",
+      "type" : "double"
+    }, {
+      "name" : "field29",
+      "type" : "string"
+    } ]
+  } ],
+  "messages" : { }
+}

--- a/avrohugger-core/src/test/scala/scavro/ScavroManyFieldsSpec.scala
+++ b/avrohugger-core/src/test/scala/scavro/ScavroManyFieldsSpec.scala
@@ -1,0 +1,92 @@
+package avrohugger
+package test
+package scavro
+
+import java.io.File
+
+import avrohugger.format.Scavro
+import org.specs2._
+
+/**
+  * Test generating classes when >22 fields.
+  */
+class ScavroManyFieldsSpec extends mutable.Specification {
+
+  val avdlPath = "avrohugger-core/src/test/avro/ManyFields.avdl"
+  val avscPath = "avrohugger-core/src/test/avro/ManyFields.avsc"
+
+  "Standard Generator " should {
+    "generate cases classes when many fields are supported with AVDLs" in {
+
+      val gen = new Generator(Scavro, restrictedFieldNumber = false)
+      val outDir = gen.defaultOutputDir + "/scavro/non-restricted"
+
+      "with AVDLs" in {
+
+        gen.fileToFile(new File(avdlPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/model/ManyFieldsProtocol.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVSCs" in {
+        gen.fileToFile(new File(avscPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/model/ManyFields.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avdlPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/model/ManyFieldsProtocol.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avscPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/model/ManyFields.scala")
+
+        source must contain("case class")
+      }
+    }
+
+    "generate classes when many fields are NOT supported" in {
+      val gen = new Generator(Scavro, restrictedFieldNumber = true)
+      val outDir = gen.defaultOutputDir + "/scavro/restricted"
+
+      "with AVDLs" in {
+        gen.fileToFile(new File(avdlPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/model/ManyFieldsProtocol.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVSCs" in {
+        gen.fileToFile(new File(avscPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/model/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avdlPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/model/ManyFieldsProtocol.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avscPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/model/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+    }
+  }
+
+}

--- a/avrohugger-core/src/test/scala/specific/SpecificManyFieldsSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificManyFieldsSpec.scala
@@ -1,0 +1,92 @@
+package avrohugger
+package test
+package specific
+
+import java.io.File
+
+import avrohugger.format.{SpecificRecord, Standard}
+import org.specs2._
+
+/**
+  * Test generating classes when >22 fields.
+  */
+class SpecificManyFieldsSpec extends mutable.Specification {
+
+  val avdlPath = "avrohugger-core/src/test/avro/ManyFields.avdl"
+  val avscPath = "avrohugger-core/src/test/avro/ManyFields.avsc"
+
+  "Standard Generator " should {
+    "generate cases classes when many fields are supported with AVDLs" in {
+
+      val gen = new Generator(SpecificRecord, restrictedFieldNumber = false)
+      val outDir = gen.defaultOutputDir + "/specific/non-restricted"
+
+      "with AVDLs" in {
+
+        gen.fileToFile(new File(avdlPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFields.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVSCs" in {
+        gen.fileToFile(new File(avscPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avdlPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFields.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avscPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must contain("case class")
+      }
+    }
+
+    "generate classes when many fields are NOT supported" in {
+      val gen = new Generator(SpecificRecord, restrictedFieldNumber = true)
+      val outDir = gen.defaultOutputDir + "/specific/restricted"
+
+      "with AVDLs" in {
+        gen.fileToFile(new File(avdlPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVSCs" in {
+        gen.fileToFile(new File(avscPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avdlPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avscPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+    }
+  }
+
+}

--- a/avrohugger-core/src/test/scala/standard/StandardManyFieldsSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardManyFieldsSpec.scala
@@ -1,0 +1,92 @@
+package avrohugger
+package test
+package standard
+
+import java.io.File
+
+import avrohugger.format.Standard
+import org.specs2._
+
+/**
+  * Test generating classes when >22 fields.
+  */
+class StandardManyFieldsSpec extends mutable.Specification {
+
+  val avdlPath = "avrohugger-core/src/test/avro/ManyFields.avdl"
+  val avscPath = "avrohugger-core/src/test/avro/ManyFields.avsc"
+
+  "Standard Generator " should {
+    "generate cases classes when many fields are supported with AVDLs" in {
+
+      val gen = new Generator(Standard, restrictedFieldNumber = false)
+      val outDir = gen.defaultOutputDir + "/standard/non-restricted"
+
+      "with AVDLs" in {
+
+        gen.fileToFile(new File(avdlPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFieldsProtocol.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVSCs" in {
+        gen.fileToFile(new File(avscPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avdlPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFieldsProtocol.scala")
+
+        source must contain("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avscPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must contain("case class")
+      }
+    }
+
+    "generate classes when many fields are NOT supported" in {
+      val gen = new Generator(Standard, restrictedFieldNumber = true)
+      val outDir = gen.defaultOutputDir + "/standard/restricted"
+
+      "with AVDLs" in {
+        gen.fileToFile(new File(avdlPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFieldsProtocol.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVSCs" in {
+        gen.fileToFile(new File(avscPath), outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avdlPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avdl/ManyFieldsProtocol.scala")
+
+        source must not contain ("case class")
+      }
+
+      "with AVDL strings" in {
+        val inputString = util.Util.readFile(avscPath)
+        gen.stringToFile(inputString, outDir)
+        val source = util.Util.readFile(s"$outDir/test/avsc/ManyFields.scala")
+
+        source must not contain ("case class")
+      }
+    }
+  }
+
+}

--- a/avrohugger-core/src/test/scala/util/Util.scala
+++ b/avrohugger-core/src/test/scala/util/Util.scala
@@ -1,24 +1,20 @@
 package util
 
 object Util {
-  
-  def readFile(fileName: String): String = {
-    
-    var count = 0
-    val maxTries = 3
-    try { // if file is empty, try again, it should be there
-      count += 1
-      val contents: String = scala.io.Source.fromFile(fileName).mkString
-      if (contents.isEmpty && (count < maxTries)) readFile(fileName)
-      else contents
-    } catch { // if file is not found, try again, it should be there
-      case e: Throwable => {
-        if (count < maxTries) readFile(fileName)
-        else sys.error("File not found: " + fileName)
+
+  def readFile(fileName: String, maxTries: Int = 3): String = {
+    def readFile0(count: Int): String = {
+      try { // if file is empty, try again, it should be there
+        val contents: String = scala.io.Source.fromFile(fileName).mkString
+        if (contents.isEmpty && (count < maxTries)) readFile0(count + 1)
+        else contents
+      } catch { // if file is not found, try again, it should be there
+        case e: Throwable =>
+          if (count < maxTries) readFile0(count + 1)
+          else sys.error("File not found: " + fileName)
       }
     }
-
-    
+    readFile0(0)
   }
-  
+
 }


### PR DESCRIPTION
Added parameter `restrictedFieldNumber` to Generator so classes are generated instead of case classes when parameter is true AND record has more than 22 fields.

Right now I'm checking for 22 fields explicitly, so it's not very generic, maybe that can be changed in the future.
