### PR TITLE
Non-case classes without a protocol should extend Serializable

### DIFF
--- a/avrohugger-core/src/main/scala/format/specific/trees/SpecificCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/specific/trees/SpecificCaseClassTree.scala
@@ -113,6 +113,7 @@ object SpecificCaseClassTree {
             .withFlags(flags:_*)
             .withParams(params)
             .withParents(baseClass)
+            .withParents("Serializable")
         }
         else if (avroFields.nonEmpty) {
           CASECLASSDEF(classSymbol)
@@ -131,6 +132,7 @@ object SpecificCaseClassTree {
           CLASSDEF(classSymbol)
             .withParams(params)
             .withParents(baseClass)
+            .withParents("Serializable")
         }
         else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -83,6 +83,7 @@ object StandardCaseClassTree {
           CLASSDEF(classSymbol)
             .withFlags(flags:_*)
             .withParams(params)
+            .withParents("Serializable")
         }
         else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)
@@ -99,6 +100,7 @@ object StandardCaseClassTree {
         if (shouldGenerateSimpleClass) {
           CLASSDEF(classSymbol)
             .withParams(params)
+            .withParents("Serializable")
         }
         else if (!avroFields.isEmpty) {
           CASECLASSDEF(classSymbol)


### PR DESCRIPTION
When non-case classes without a protocol are generated they should extend Serializable.

or bad things will happen
