### PR TITLE
handle snake cased fields

### DIFF
--- a/avrohugger-core/src/main/scala/format/scavro/converters/ScalaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/converters/ScalaConverter.scala
@@ -31,7 +31,7 @@ class ScalaConverter(typeMatcher: TypeMatcher) {
       case Schema.Type.RECORD => {
         val params = schema.getFields.asScala.flatMap(field => {
           val updatedPath = field.schema.getFullName :: fieldPath
-          val accessorName = "get" + field.name.head.toUpper + field.name.tail
+          val accessorName = "get" + field.name.split("_").map(_.capitalize).mkString("")
           val updatedTree = tree DOT(accessorName)
           if (fieldPath.contains(field.schema.getFullName)) List.empty
           else List(convertFromJava(field.schema, updatedTree, updatedPath))

--- a/avrohugger-core/src/main/scala/format/scavro/trees/ScavroObjectTree.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/trees/ScavroObjectTree.scala
@@ -75,7 +75,7 @@ object ScavroObjectTree {
 
     val javaClassAccessors: List[Tree] =
       schema.getFields.asScala.toList.map(avroField => {
-        val nameGet = "get" + avroField.name.head.toUpper + avroField.name.tail
+        val nameGet = "get" + avroField.name.split("_").map(_.capitalize).mkString("")
         val getterTree = REF("j") DOT nameGet
         val scalaConverter = new ScalaConverter(typeMatcher)
         scalaConverter.convertFromJava(avroField.schema, getterTree)

--- a/avrohugger-core/src/test/expected/comments/scavro/Example4.scala
+++ b/avrohugger-core/src/test/expected/comments/scavro/Example4.scala
@@ -25,7 +25,7 @@ final object NoSpaces4 {
     override val avroClass: Class[JNoSpaces4] = classOf[JNoSpaces4]
     override val schema: Schema = JNoSpaces4.getClassSchema()
     override val fromAvro: (JNoSpaces4) => NoSpaces4 = {
-      (j: JNoSpaces4) => NoSpaces4(j.getComment_property1.toString)
+      (j: JNoSpaces4) => NoSpaces4(j.getCommentProperty1.toString)
     }
   }
 }
@@ -45,7 +45,7 @@ final object NoSpaces5 {
     override val avroClass: Class[JNoSpaces5] = classOf[JNoSpaces5]
     override val schema: Schema = JNoSpaces5.getClassSchema()
     override val fromAvro: (JNoSpaces5) => NoSpaces5 = {
-      (j: JNoSpaces5) => NoSpaces5(j.getComment_property2.toString)
+      (j: JNoSpaces5) => NoSpaces5(j.getCommentProperty2.toString)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/comments/scavro/NoSpaces1.scala
+++ b/avrohugger-core/src/test/expected/comments/scavro/NoSpaces1.scala
@@ -47,7 +47,7 @@ object NoSpaces1 {
     override val avroClass: Class[JNoSpaces1] = classOf[JNoSpaces1]
     override val schema: Schema = JNoSpaces1.getClassSchema()
     override val fromAvro: (JNoSpaces1) => NoSpaces1 = {
-      (j: JNoSpaces1) => NoSpaces1(j.getSingle_line_comment_property.toString, j.getMulti_line_property.toString)
+      (j: JNoSpaces1) => NoSpaces1(j.getSingleLineCommentProperty.toString, j.getMultiLineProperty.toString)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/comments/scavro/NoSpaces2.scala
+++ b/avrohugger-core/src/test/expected/comments/scavro/NoSpaces2.scala
@@ -26,7 +26,7 @@ object NoSpaces2 {
     override val avroClass: Class[JNoSpaces2] = classOf[JNoSpaces2]
     override val schema: Schema = JNoSpaces2.getClassSchema()
     override val fromAvro: (JNoSpaces2) => NoSpaces2 = {
-      (j: JNoSpaces2) => NoSpaces2(j.getComment_property.toString)
+      (j: JNoSpaces2) => NoSpaces2(j.getCommentProperty.toString)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/comments/scavro/NoSpaces3.scala
+++ b/avrohugger-core/src/test/expected/comments/scavro/NoSpaces3.scala
@@ -30,7 +30,7 @@ object NoSpaces3 {
     override val avroClass: Class[JNoSpaces3] = classOf[JNoSpaces3]
     override val schema: Schema = JNoSpaces3.getClassSchema()
     override val fromAvro: (JNoSpaces3) => NoSpaces3 = {
-      (j: JNoSpaces3) => NoSpaces3(j.getComment_property.toString)
+      (j: JNoSpaces3) => NoSpaces3(j.getCommentProperty.toString)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/model/User.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/User.scala
@@ -28,12 +28,12 @@ object User {
     override val avroClass: Class[JUser] = classOf[JUser]
     override val schema: Schema = JUser.getClassSchema()
     override val fromAvro: (JUser) => User = {
-      (j: JUser) => User(j.getName.toString, j.getFavorite_number match {
+      (j: JUser) => User(j.getName.toString, j.getFavoriteNumber match {
         case null => None
-        case _ => Some(j.getFavorite_number.toInt)
-      }, j.getFavorite_color match {
+        case _ => Some(j.getFavoriteNumber.toInt)
+      }, j.getFavoriteColor match {
         case null => None
-        case _ => Some(j.getFavorite_color.toString)
+        case _ => Some(j.getFavoriteColor.toString)
       })
     }
   }

--- a/avrohugger-tools/src/test/compiler/output-scavro/avro/examples/baseball/Player.scala
+++ b/avrohugger-tools/src/test/compiler/output-scavro/avro/examples/baseball/Player.scala
@@ -30,7 +30,7 @@ object Player {
     override val avroClass: Class[JPlayer] = classOf[JPlayer]
     override val schema: Schema = JPlayer.getClassSchema()
     override val fromAvro: (JPlayer) => Player = {
-      (j: JPlayer) => Player(j.getNumber.toInt, j.getFirst_name.toString, j.getLast_name.toString, Array((j.getNicknames: _*)) map { x =>
+      (j: JPlayer) => Player(j.getNumber.toInt, j.getFirstName.toString, j.getLastName.toString, Array((j.getNicknames: _*)) map { x =>
         Nickname(x.getName.toString)
       })
     }


### PR DESCRIPTION
If there is a snake cased field, e.g. `user_id`, the avro compiler will generate getters/setters of the form: `getUserId()`, not `getUser_id()`. Currently, avrohugger is generating the latter form. 

