### PR TITLE
fix: allow to use full name in default value reference

### DIFF
--- a/avrohugger-core/src/main/scala/format/specific/trees/SpecificCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/specific/trees/SpecificCaseClassTree.scala
@@ -35,7 +35,7 @@ object SpecificCaseClassTree {
     val params: List[ValDef] = avroFields.map { f =>
       val fieldName = f.name
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
-      val defaultValue = DefaultValueMatcher.getDefaultValue(f, typeMatcher)
+      val defaultValue = DefaultValueMatcher.getDefaultValue(f, typeMatcher, fieldName == fieldType.safeToString)
       VAR(fieldName, fieldType) := defaultValue
     }
 

--- a/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
@@ -17,7 +17,9 @@ object DefaultValueMatcher {
   
   // This code was stolen from here:
   // https://github.com/julianpeeters/avro-scala-macro-annotations/blob/104fa325a00044ff6d31184fa7ff7b6852e9acd5/macros/src/main/scala/avro/scala/macro/annotations/provider/matchers/FromJsonMatcher.scala
-  def getDefaultValue(field: Schema.Field, typeMatcher: TypeMatcher): Tree = {
+  def getDefaultValue(field: Schema.Field,
+                      typeMatcher: TypeMatcher,
+                      useFullName: Boolean = false): Tree = {
 
     val nullNode = new TextNode("null")
 
@@ -34,7 +36,9 @@ object DefaultValueMatcher {
           val x = node.getTextValue.getBytes.map((e: Byte) => LIT(e))
           REF("Array[Byte]") APPLY x
         }
-        case Schema.Type.ENUM => (REF(schema.getName) DOT node.getTextValue)
+        case Schema.Type.ENUM =>
+          val refName = if (useFullName) schema.getFullName else schema.getName
+          REF(refName) DOT node.getTextValue
         case Schema.Type.NULL => LIT(null)
         case Schema.Type.UNION => {
           val unionSchemas = schema.getTypes.asScala.toList

--- a/avrohugger-core/src/test/avro/field_type_equals_field_name.avsc
+++ b/avrohugger-core/src/test/avro/field_type_equals_field_name.avsc
@@ -1,0 +1,17 @@
+{
+  "namespace": "example",
+  "name": "Room",
+  "type": "record",
+  "fields": [
+    {
+      "name": "door",
+      "default": "NORTH",
+      "type": {
+        "name": "door",
+        "namespace" : "example.types",
+        "type": "enum",
+        "symbols" : ["NORTH", "SOUTH", "EAST", "WEST"]
+      }
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/specific/example/Room.scala
+++ b/avrohugger-core/src/test/expected/specific/example/Room.scala
@@ -1,0 +1,32 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example
+
+import scala.annotation.switch
+
+import example.types.door
+
+case class Room(var door: door = example.types.door.NORTH) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(example.types.door.NORTH)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        door
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.door = {
+        value
+      }.asInstanceOf[door]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = Room.SCHEMA$
+}
+
+object Room {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Room\",\"namespace\":\"example\",\"fields\":[{\"name\":\"door\",\"type\":{\"type\":\"enum\",\"name\":\"door\",\"namespace\":\"example.types\",\"symbols\":[\"NORTH\",\"SOUTH\",\"EAST\",\"WEST\"]},\"default\":\"NORTH\"}]}")
+}

--- a/avrohugger-core/src/test/scala/specific/SpecificDefaultValueFullnameSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificDefaultValueFullnameSpec.scala
@@ -1,0 +1,18 @@
+package specific
+
+import avrohugger._
+import avrohugger.format.SpecificRecord
+import org.specs2._
+
+class SpecificDefaultValueFullnameSpec extends mutable.Specification {
+  "a Generator" should {
+    "use the fully qualified name if field name equals type name" in {
+      val infile = new java.io.File("avrohugger-core/src/test/avro/field_type_equals_field_name.avsc")
+      val gen = new Generator(SpecificRecord)
+      val outDir = gen.defaultOutputDir + "/specific/"
+      gen.fileToFile(infile, outDir)
+      val sourceRecord = scala.io.Source.fromFile(s"$outDir/example/Room.scala").mkString
+      sourceRecord ==== util.Util.readFile("avrohugger-core/src/test/expected/specific/example/Room.scala")
+    }
+  }
+}


### PR DESCRIPTION
For schemas where a field with default value has the same name as its
type, avrohugger will produce code that does not compile, because the
compiler does not know if the reference is related to the field or the
imported type.

This is a small fix which just checks for this condition and uses the
full name in the reference in that case. Currently this only done for
the `specific` generation to provide a minimal invasive PR, but should
also apply to the others.