### PR TITLE
Scavro nested clash

### DIFF
--- a/avrohugger-core/src/main/scala/format/scavro/converters/JavaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/converters/JavaConverter.scala
@@ -49,21 +49,7 @@ class JavaConverter(
         tree MATCH(conversionCases)
       }
       case Schema.Type.RECORD => {
-        val scalaClass = classStore.generatedClasses(schema)
-        val javaClass = REF("J" + scalaClass.toString)
-        val ids = schema.getFields.asScala.map(field => ID(field.name))
-        val fieldConversions = schema.getFields.asScala.flatMap(field => {
-          val updatedPath = field.schema.getFullName :: fieldPath
-          if (fieldPath.contains(field.schema.getFullName)) List.empty
-          else List(convertToJava(field.schema, REF(field.name), updatedPath))
-        //  REF(field.name)
-        })
-        val conversionCases = List(
-          CASE(scalaClass UNAPPLY(ids)) ==> {
-            NEW(javaClass APPLY(fieldConversions))
-          }
-        )
-        tree MATCH(conversionCases:_*)
+        tree DOT "toAvro"
       }
       case Schema.Type.UNION => {
         val types = schema.getTypes.asScala

--- a/avrohugger-core/src/main/scala/format/scavro/converters/ScalaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/converters/ScalaConverter.scala
@@ -29,14 +29,7 @@ class ScalaConverter(typeMatcher: TypeMatcher) {
         tree MATCH(conversionCases)
       }
       case Schema.Type.RECORD => {
-        val params = schema.getFields.asScala.flatMap(field => {
-          val updatedPath = field.schema.getFullName :: fieldPath
-          val accessorName = ScavroMethodRenamer.generateMethodName(schema, field, "get", "")
-          val updatedTree = tree DOT(accessorName)
-          if (fieldPath.contains(field.schema.getFullName)) List.empty
-          else List(convertFromJava(field.schema, updatedTree, updatedPath))
-        })
-        REF(schema.getName) APPLY params
+        REF(schema.getName).DOT("metadata").DOT("fromAvro").APPLY(tree)
       }
       case Schema.Type.UNION  => {
         val types = schema.getTypes.asScala

--- a/avrohugger-core/src/test/avro/clash.avsc
+++ b/avrohugger-core/src/test/avro/clash.avsc
@@ -1,0 +1,48 @@
+{
+  "type": "record",
+  "name": "ClashRecord",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "some",
+      "type": "int"
+    },
+    {
+      "name": "outer",
+      "type": {
+        "type": "record",
+        "name": "ClashOuter",
+        "fields": [
+          {
+            "name": "inner",
+            "type": ["null", {
+              "type": "array",
+              "items": ["null", {
+                "type": "record",
+                "name": "ClashInner",
+                "fields": [
+                  {
+                    "name": "some",
+                    "type": ["null", "int"]
+                  },
+                  {
+                    "name": "other",
+                    "type": ["null", "int"]
+                  },
+                  {
+                    "name": "id",
+                    "type": ["null", "int"]
+                  }
+                ]
+              }]
+            }]
+          }
+        ]
+      }
+    },
+    {
+      "name": "id",
+      "type": "int"
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/scavro/example/idl/case/model/Defaults.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/case/model/Defaults.scala
@@ -54,9 +54,7 @@ final case class DefaultTest(suit: DefaultEnum = DefaultEnum.SPADES, number: Int
     }, optionStringValue match {
       case Some(x) => x
       case None => null
-    }, embedded match {
-      case Embedded(inner) => new JEmbedded(inner)
-    }, {
+    }, embedded.toAvro, {
       val array: java.util.List[java.lang.Integer] = new java.util.ArrayList[java.lang.Integer]
       defaultArray foreach { element =>
         array.add(element)
@@ -101,7 +99,7 @@ final object DefaultTest {
       }, j.getOptionStringValue match {
         case null => None
         case _ => Some(j.getOptionStringValue.toString)
-      }, Embedded(j.getEmbedded.getInner.toInt), Array((j.getDefaultArray.asScala: _*)) map { x =>
+      }, Embedded.metadata.fromAvro(j.getEmbedded), Array((j.getDefaultArray.asScala: _*)) map { x =>
         x.toInt
       }, j.getOptionalEnum match {
         case null => None

--- a/avrohugger-core/src/test/expected/scavro/example/idl/case/model/ImportProtocol.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/case/model/ImportProtocol.scala
@@ -16,9 +16,7 @@ sealed trait ImportProtocol extends AvroSerializeable with Product with Serializ
 final case class DependentRecord(dependency: ExternalDependency, number: Int) extends AvroSerializeable with ImportProtocol {
   type J = JDependentRecord
   override def toAvro: JDependentRecord = {
-    new JDependentRecord(dependency match {
-      case ExternalDependency(number) => new JExternalDependency(number)
-    }, number)
+    new JDependentRecord(dependency.toAvro, number)
   }
 }
 
@@ -30,7 +28,7 @@ final object DependentRecord {
     override val avroClass: Class[JDependentRecord] = classOf[JDependentRecord]
     override val schema: Schema = JDependentRecord.getClassSchema()
     override val fromAvro: (JDependentRecord) => DependentRecord = {
-      (j: JDependentRecord) => DependentRecord(ExternalDependency(j.getDependency.getNumber.toInt), j.getNumber.toInt)
+      (j: JDependentRecord) => DependentRecord(ExternalDependency.metadata.fromAvro(j.getDependency), j.getNumber.toInt)
     }
   }
 }
@@ -68,9 +66,7 @@ final object DependentRecord2 {
 final case class DependentRecord3(dependency: Embedded, value: Boolean) extends AvroSerializeable with ImportProtocol {
   type J = JDependentRecord3
   override def toAvro: JDependentRecord3 = {
-    new JDependentRecord3(dependency match {
-      case Embedded(inner) => new JEmbedded(inner)
-    }, value)
+    new JDependentRecord3(dependency.toAvro, value)
   }
 }
 
@@ -82,7 +78,7 @@ final object DependentRecord3 {
     override val avroClass: Class[JDependentRecord3] = classOf[JDependentRecord3]
     override val schema: Schema = JDependentRecord3.getClassSchema()
     override val fromAvro: (JDependentRecord3) => DependentRecord3 = {
-      (j: JDependentRecord3) => DependentRecord3(Embedded(j.getDependency.getInner.toInt), j.getValue)
+      (j: JDependentRecord3) => DependentRecord3(Embedded.metadata.fromAvro(j.getDependency), j.getValue)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/idl/java/model/Defaults.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/java/model/Defaults.scala
@@ -45,9 +45,7 @@ final case class DefaultTest(suit: DefaultEnum = DefaultEnum.SPADES, number: Int
     }, optionStringValue match {
       case Some(x) => x
       case None => null
-    }, embedded match {
-      case Embedded(inner) => new JEmbedded(inner)
-    }, {
+    }, embedded.toAvro, {
       val array: java.util.List[java.lang.Integer] = new java.util.ArrayList[java.lang.Integer]
       defaultArray foreach { element =>
         array.add(element)
@@ -92,7 +90,7 @@ final object DefaultTest {
       }, j.getOptionStringValue match {
         case null => None
         case _ => Some(j.getOptionStringValue.toString)
-      }, Embedded(j.getEmbedded.getInner.toInt), Array((j.getDefaultArray.asScala: _*)) map { x =>
+      }, Embedded.metadata.fromAvro(j.getEmbedded), Array((j.getDefaultArray.asScala: _*)) map { x =>
         x.toInt
       }, j.getOptionalEnum match {
         case null => None

--- a/avrohugger-core/src/test/expected/scavro/example/idl/java/model/ImportProtocol.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/java/model/ImportProtocol.scala
@@ -16,9 +16,7 @@ sealed trait ImportProtocol extends AvroSerializeable with Product with Serializ
 final case class DependentRecord(dependency: ExternalDependency, number: Int) extends AvroSerializeable with ImportProtocol {
   type J = JDependentRecord
   override def toAvro: JDependentRecord = {
-    new JDependentRecord(dependency match {
-      case ExternalDependency(number) => new JExternalDependency(number)
-    }, number)
+    new JDependentRecord(dependency.toAvro, number)
   }
 }
 
@@ -30,7 +28,7 @@ final object DependentRecord {
     override val avroClass: Class[JDependentRecord] = classOf[JDependentRecord]
     override val schema: Schema = JDependentRecord.getClassSchema()
     override val fromAvro: (JDependentRecord) => DependentRecord = {
-      (j: JDependentRecord) => DependentRecord(ExternalDependency(j.getDependency.getNumber.toInt), j.getNumber.toInt)
+      (j: JDependentRecord) => DependentRecord(ExternalDependency.metadata.fromAvro(j.getDependency), j.getNumber.toInt)
     }
   }
 }
@@ -68,9 +66,7 @@ final object DependentRecord2 {
 final case class DependentRecord3(dependency: Embedded, value: Boolean) extends AvroSerializeable with ImportProtocol {
   type J = JDependentRecord3
   override def toAvro: JDependentRecord3 = {
-    new JDependentRecord3(dependency match {
-      case Embedded(inner) => new JEmbedded(inner)
-    }, value)
+    new JDependentRecord3(dependency.toAvro, value)
   }
 }
 
@@ -82,7 +78,7 @@ final object DependentRecord3 {
     override val avroClass: Class[JDependentRecord3] = classOf[JDependentRecord3]
     override val schema: Schema = JDependentRecord3.getClassSchema()
     override val fromAvro: (JDependentRecord3) => DependentRecord3 = {
-      (j: JDependentRecord3) => DependentRecord3(Embedded(j.getDependency.getInner.toInt), j.getValue)
+      (j: JDependentRecord3) => DependentRecord3(Embedded.metadata.fromAvro(j.getDependency), j.getValue)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Defaults.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Defaults.scala
@@ -50,9 +50,7 @@ final case class DefaultTest(suit: DefaultEnum.Value = DefaultEnum.SPADES, numbe
     }, optionStringValue match {
       case Some(x) => x
       case None => null
-    }, embedded match {
-      case Embedded(inner) => new JEmbedded(inner)
-    }, {
+    }, embedded.toAvro, {
       val array: java.util.List[java.lang.Integer] = new java.util.ArrayList[java.lang.Integer]
       defaultArray foreach { element =>
         array.add(element)
@@ -97,7 +95,7 @@ final object DefaultTest {
       }, j.getOptionStringValue match {
         case null => None
         case _ => Some(j.getOptionStringValue.toString)
-      }, Embedded(j.getEmbedded.getInner.toInt), Array((j.getDefaultArray.asScala: _*)) map { x =>
+      }, Embedded.metadata.fromAvro(j.getEmbedded), Array((j.getDefaultArray.asScala: _*)) map { x =>
         x.toInt
       }, j.getOptionalEnum match {
         case null => None

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/ImportProtocol.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/ImportProtocol.scala
@@ -16,9 +16,7 @@ sealed trait ImportProtocol extends AvroSerializeable with Product with Serializ
 final case class DependentRecord(dependency: ExternalDependency, number: Int) extends AvroSerializeable with ImportProtocol {
   type J = JDependentRecord
   override def toAvro: JDependentRecord = {
-    new JDependentRecord(dependency match {
-      case ExternalDependency(number) => new JExternalDependency(number)
-    }, number)
+    new JDependentRecord(dependency.toAvro, number)
   }
 }
 
@@ -30,7 +28,7 @@ final object DependentRecord {
     override val avroClass: Class[JDependentRecord] = classOf[JDependentRecord]
     override val schema: Schema = JDependentRecord.getClassSchema()
     override val fromAvro: (JDependentRecord) => DependentRecord = {
-      (j: JDependentRecord) => DependentRecord(ExternalDependency(j.getDependency.getNumber.toInt), j.getNumber.toInt)
+      (j: JDependentRecord) => DependentRecord(ExternalDependency.metadata.fromAvro(j.getDependency), j.getNumber.toInt)
     }
   }
 }
@@ -68,9 +66,7 @@ final object DependentRecord2 {
 final case class DependentRecord3(dependency: Embedded, value: Boolean) extends AvroSerializeable with ImportProtocol {
   type J = JDependentRecord3
   override def toAvro: JDependentRecord3 = {
-    new JDependentRecord3(dependency match {
-      case Embedded(inner) => new JEmbedded(inner)
-    }, value)
+    new JDependentRecord3(dependency.toAvro, value)
   }
 }
 
@@ -82,7 +78,7 @@ final object DependentRecord3 {
     override val avroClass: Class[JDependentRecord3] = classOf[JDependentRecord3]
     override val schema: Schema = JDependentRecord3.getClassSchema()
     override val fromAvro: (JDependentRecord3) => DependentRecord3 = {
-      (j: JDependentRecord3) => DependentRecord3(Embedded(j.getDependency.getInner.toInt), j.getValue)
+      (j: JDependentRecord3) => DependentRecord3(Embedded.metadata.fromAvro(j.getDependency), j.getValue)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/NestedProtocol.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/NestedProtocol.scala
@@ -32,9 +32,7 @@ final object Level2 {
 final case class Level1(level2: Level2) extends AvroSerializeable with NestedProtocol {
   type J = JLevel1
   override def toAvro: JLevel1 = {
-    new JLevel1(level2 match {
-      case Level2(name) => new JLevel2(name)
-    })
+    new JLevel1(level2.toAvro)
   }
 }
 
@@ -46,7 +44,7 @@ final object Level1 {
     override val avroClass: Class[JLevel1] = classOf[JLevel1]
     override val schema: Schema = JLevel1.getClassSchema()
     override val fromAvro: (JLevel1) => Level1 = {
-      (j: JLevel1) => Level1(Level2(j.getLevel2.getName.toString))
+      (j: JLevel1) => Level1(Level2.metadata.fromAvro(j.getLevel2))
     }
   }
 }
@@ -54,11 +52,7 @@ final object Level1 {
 final case class Level0(level1: Level1) extends AvroSerializeable with NestedProtocol {
   type J = JLevel0
   override def toAvro: JLevel0 = {
-    new JLevel0(level1 match {
-      case Level1(level2) => new JLevel1(level2 match {
-        case Level2(name) => new JLevel2(name)
-      })
-    })
+    new JLevel0(level1.toAvro)
   }
 }
 
@@ -70,7 +64,7 @@ final object Level0 {
     override val avroClass: Class[JLevel0] = classOf[JLevel0]
     override val schema: Schema = JLevel0.getClassSchema()
     override val fromAvro: (JLevel0) => Level0 = {
-      (j: JLevel0) => Level0(Level1(Level2(j.getLevel1.getLevel2.getName.toString)))
+      (j: JLevel0) => Level0(Level1.metadata.fromAvro(j.getLevel1))
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Recursive.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Recursive.scala
@@ -11,14 +11,7 @@ case class Recursive(name: String, recursive: Option[Recursive]) extends AvroSer
   type J = JRecursive
   override def toAvro: JRecursive = {
     new JRecursive(name, recursive match {
-      case Some(x) => x match {
-        case Recursive(name, recursive) => new JRecursive(name, recursive match {
-          case Some(x) => x match {
-            case Recursive(name, recursive) => new JRecursive(name)
-          }
-          case None => null
-        })
-      }
+      case Some(x) => x.toAvro
       case None => null
     })
   }
@@ -34,10 +27,7 @@ object Recursive {
     override val fromAvro: (JRecursive) => Recursive = {
       (j: JRecursive) => Recursive(j.getName.toString, j.getRecursive match {
         case null => None
-        case _ => Some(Recursive(j.getRecursive.getName.toString, j.getRecursive.getRecursive match {
-          case null => None
-          case _ => Some(Recursive(j.getRecursive.getRecursive.getName.toString))
-        }))
+        case _ => Some(Recursive.metadata.fromAvro(j.getRecursive))
       })
     }
   }

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashInner.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashInner.scala
@@ -1,0 +1,46 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.avro.model
+
+import org.apache.avro.Schema
+
+import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
+
+import example.avro.{ClashInner => JClashInner}
+
+case class ClashInner(some: Option[Int], other: Option[Int], id: Option[Int]) extends AvroSerializeable {
+  type J = JClashInner
+  override def toAvro: JClashInner = {
+    new JClashInner(some match {
+      case Some(x) => x
+      case None => null
+    }, other match {
+      case Some(x) => x
+      case None => null
+    }, id match {
+      case Some(x) => x
+      case None => null
+    })
+  }
+}
+
+object ClashInner {
+  implicit def reader = new AvroReader[ClashInner] {
+    override type J = JClashInner
+  }
+  implicit val metadata: AvroMetadata[ClashInner, JClashInner] = new AvroMetadata[ClashInner, JClashInner] {
+    override val avroClass: Class[JClashInner] = classOf[JClashInner]
+    override val schema: Schema = JClashInner.getClassSchema()
+    override val fromAvro: (JClashInner) => ClashInner = {
+      (j: JClashInner) => ClashInner(j.getSome match {
+        case null => None
+        case _ => Some(j.getSome.toInt)
+      }, j.getOther match {
+        case null => None
+        case _ => Some(j.getOther.toInt)
+      }, j.getId match {
+        case null => None
+        case _ => Some(j.getId.toInt)
+      })
+    }
+  }
+}

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala
@@ -1,0 +1,70 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.avro.model
+
+import org.apache.avro.Schema
+
+import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
+
+import example.avro.{ClashInner => JClashInner, ClashOuter => JClashOuter}
+
+import scala.collection.JavaConverters._
+
+case class ClashOuter(inner: Option[Array[Option[ClashInner]]]) extends AvroSerializeable {
+  type J = JClashOuter
+  override def toAvro: JClashOuter = {
+    new JClashOuter(inner match {
+      case Some(x) => {
+        val array: java.util.List[JClashInner] = new java.util.ArrayList[JClashInner]
+        x foreach { element =>
+          array.add(element match {
+            case Some(x) => x match {
+              case ClashInner(some, other, id) => new JClashInner(some match {
+                case Some(x) => x
+                case None => null
+              }, other match {
+                case Some(x) => x
+                case None => null
+              }, id match {
+                case Some(x) => x
+                case None => null
+              })
+            }
+            case None => null
+          })
+        }
+        array
+      }
+      case None => null
+    })
+  }
+}
+
+object ClashOuter {
+  implicit def reader = new AvroReader[ClashOuter] {
+    override type J = JClashOuter
+  }
+  implicit val metadata: AvroMetadata[ClashOuter, JClashOuter] = new AvroMetadata[ClashOuter, JClashOuter] {
+    override val avroClass: Class[JClashOuter] = classOf[JClashOuter]
+    override val schema: Schema = JClashOuter.getClassSchema()
+    override val fromAvro: (JClashOuter) => ClashOuter = {
+      (j: JClashOuter) => ClashOuter(j.getInner match {
+        case null => None
+        case _ => Some(Array((j.getInner.asScala: _*)) map { x =>
+          x match {
+            case null => None
+            case _ => Some(ClashInner(x.getSome match {
+              case null => None
+              case _ => Some(x.getSome.toInt)
+            }, x.getOther match {
+              case null => None
+              case _ => Some(x.getOther.toInt)
+            }, x.getId match {
+              case null => None
+              case _ => Some(x.getId.toInt)
+            }))
+          }
+        })
+      })
+    }
+  }
+}

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala
@@ -17,18 +17,7 @@ case class ClashOuter(inner: Option[Array[Option[ClashInner]]]) extends AvroSeri
         val array: java.util.List[JClashInner] = new java.util.ArrayList[JClashInner]
         x foreach { element =>
           array.add(element match {
-            case Some(x) => x match {
-              case ClashInner(some, other, id) => new JClashInner(some match {
-                case Some(x) => x
-                case None => null
-              }, other match {
-                case Some(x) => x
-                case None => null
-              }, id match {
-                case Some(x) => x
-                case None => null
-              })
-            }
+            case Some(x) => x.toAvro
             case None => null
           })
         }
@@ -52,16 +41,7 @@ object ClashOuter {
         case _ => Some(Array((j.getInner.asScala: _*)) map { x =>
           x match {
             case null => None
-            case _ => Some(ClashInner(x.getSome match {
-              case null => None
-              case _ => Some(x.getSome.toInt)
-            }, x.getOther match {
-              case null => None
-              case _ => Some(x.getOther.toInt)
-            }, x.getId match {
-              case null => None
-              case _ => Some(x.getId.toInt)
-            }))
+            case _ => Some(ClashInner.metadata.fromAvro(x))
           }
         })
       })

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
@@ -5,39 +5,14 @@ import org.apache.avro.Schema
 
 import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
-import example.avro.{ClashInner => JClashInner, ClashRecord => JClashRecord, ClashOuter => JClashOuter}
+import example.avro.{ClashInner => JClashInner, ClashOuter => JClashOuter, ClashRecord => JClashRecord}
 
 import scala.collection.JavaConverters._
 
 case class ClashRecord(some: Int, outer: ClashOuter, id: Int) extends AvroSerializeable {
   type J = JClashRecord
   override def toAvro: JClashRecord = {
-    new JClashRecord(some, outer match {
-      case ClashOuter(inner) => new JClashOuter(inner match {
-        case Some(x) => {
-          val array: java.util.List[JClashInner] = new java.util.ArrayList[JClashInner]
-          x foreach { element =>
-            array.add(element match {
-              case Some(x) => x match {
-                case ClashInner(some, other, id) => new JClashInner(some match {
-                  case Some(x) => x
-                  case None => null
-                }, other match {
-                  case Some(x) => x
-                  case None => null
-                }, id match {
-                  case Some(x) => x
-                  case None => null
-                })
-              }
-              case None => null
-            })
-          }
-          array
-        }
-        case None => null
-      })
-    }, id)
+    new JClashRecord(some, outer.toAvro, id)
   }
 }
 
@@ -45,28 +20,11 @@ object ClashRecord {
   implicit def reader = new AvroReader[ClashRecord] {
     override type J = JClashRecord
   }
-  implicit val metadata: AvroMetadata[ClashRecord, JClashRecord] = new AvroMetadata[ClashRecord, JMessy] {
+  implicit val metadata: AvroMetadata[ClashRecord, JClashRecord] = new AvroMetadata[ClashRecord, JClashRecord] {
     override val avroClass: Class[JClashRecord] = classOf[JClashRecord]
     override val schema: Schema = JClashRecord.getClassSchema()
     override val fromAvro: (JClashRecord) => ClashRecord = {
-      (j: JClashRecord) => ClashRecord(j.getSome.toInt, ClashOuter(j.getOuter.getInner match {
-        case null => None
-        case _ => Some(Array((j.getOuter.getInner.asScala: _*)) map { x =>
-          x match {
-            case null => None
-            case _ => Some(ClashInner(x.getSome match {
-              case null => None
-              case _ => Some(x.getSome.toInt)
-            }, x.getOther match {
-              case null => None
-              case _ => Some(x.getOther.toInt)
-            }, x.getId match {
-              case null => None
-              case _ => Some(x.getId.toInt)
-            }))
-          }
-        })
-      }), j.getId.toInt)
+      (j: JClashRecord) => ClashRecord(j.getSome.toInt, ClashOuter.metadata.fromAvro(j.getOuter), j.getId.toInt)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
@@ -1,0 +1,72 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.avro.model
+
+import org.apache.avro.Schema
+
+import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
+
+import example.avro.{ClashInner => JClashInner, ClashRecord => JClashRecord, ClashOuter => JClashOuter}
+
+import scala.collection.JavaConverters._
+
+case class ClashRecord(some: Int, outer: ClashOuter, id: Int) extends AvroSerializeable {
+  type J = JClashRecord
+  override def toAvro: JClashRecord = {
+    new JClashRecord(some, outer match {
+      case ClashOuter(inner) => new JClashOuter(inner match {
+        case Some(x) => {
+          val array: java.util.List[JClashInner] = new java.util.ArrayList[JClashInner]
+          x foreach { element =>
+            array.add(element match {
+              case Some(x) => x match {
+                case ClashInner(some, other, id) => new JClashInner(some match {
+                  case Some(x) => x
+                  case None => null
+                }, other match {
+                  case Some(x) => x
+                  case None => null
+                }, id match {
+                  case Some(x) => x
+                  case None => null
+                })
+              }
+              case None => null
+            })
+          }
+          array
+        }
+        case None => null
+      })
+    }, id)
+  }
+}
+
+object ClashRecord {
+  implicit def reader = new AvroReader[ClashRecord] {
+    override type J = JClashRecord
+  }
+  implicit val metadata: AvroMetadata[ClashRecord, JClashRecord] = new AvroMetadata[ClashRecord, JMessy] {
+    override val avroClass: Class[JClashRecord] = classOf[JClashRecord]
+    override val schema: Schema = JClashRecord.getClassSchema()
+    override val fromAvro: (JClashRecord) => ClashRecord = {
+      (j: JClashRecord) => ClashRecord(j.getSome.toInt, ClashOuter(j.getOuter.getInner match {
+        case null => None
+        case _ => Some(Array((j.getOuter.getInner.asScala: _*)) map { x =>
+          x match {
+            case null => None
+            case _ => Some(ClashInner(x.getSome match {
+              case null => None
+              case _ => Some(x.getSome.toInt)
+            }, x.getOther match {
+              case null => None
+              case _ => Some(x.getOther.toInt)
+            }, x.getId match {
+              case null => None
+              case _ => Some(x.getId.toInt)
+            }))
+          }
+        })
+      }), j.getId.toInt)
+    }
+  }
+}

--- a/avrohugger-core/src/test/expected/scavro/example/model/Level0.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/Level0.scala
@@ -10,11 +10,7 @@ import example.{Level0 => JLevel0, Level1 => JLevel1, Level2 => JLevel2}
 case class Level0(level1: Level1) extends AvroSerializeable {
   type J = JLevel0
   override def toAvro: JLevel0 = {
-    new JLevel0(level1 match {
-      case Level1(level2) => new JLevel1(level2 match {
-        case Level2(name) => new JLevel2(name)
-      })
-    })
+    new JLevel0(level1.toAvro)
   }
 }
 
@@ -26,7 +22,7 @@ object Level0 {
     override val avroClass: Class[JLevel0] = classOf[JLevel0]
     override val schema: Schema = JLevel0.getClassSchema()
     override val fromAvro: (JLevel0) => Level0 = {
-      (j: JLevel0) => Level0(Level1(Level2(j.getLevel1.getLevel2.getName.toString)))
+      (j: JLevel0) => Level0(Level1.metadata.fromAvro(j.getLevel1))
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/model/Level1.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/Level1.scala
@@ -10,9 +10,7 @@ import example.{Level1 => JLevel1, Level2 => JLevel2}
 case class Level1(level2: Level2) extends AvroSerializeable {
   type J = JLevel1
   override def toAvro: JLevel1 = {
-    new JLevel1(level2 match {
-      case Level2(name) => new JLevel2(name)
-    })
+    new JLevel1(level2.toAvro)
   }
 }
 
@@ -24,7 +22,7 @@ object Level1 {
     override val avroClass: Class[JLevel1] = classOf[JLevel1]
     override val schema: Schema = JLevel1.getClassSchema()
     override val fromAvro: (JLevel1) => Level1 = {
-      (j: JLevel1) => Level1(Level2(j.getLevel2.getName.toString))
+      (j: JLevel1) => Level1(Level2.metadata.fromAvro(j.getLevel2))
     }
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/model/v2/model/NestedRecord.scala
+++ b/avrohugger-core/src/test/expected/scavro/model/v2/model/NestedRecord.scala
@@ -15,9 +15,7 @@ case class NestedRecord(nestedunion: Option[UnionRecord]) extends AvroSerializea
   type J = JNestedRecord
   override def toAvro: JNestedRecord = {
     new JNestedRecord(nestedunion match {
-      case Some(x) => x match {
-        case UnionRecord(blah) => new JUnionRecord(blah)
-      }
+      case Some(x) => x.toAvro
       case None => null
     })
   }
@@ -33,7 +31,7 @@ object NestedRecord {
     override val fromAvro: (JNestedRecord) => NestedRecord = {
       (j: JNestedRecord) => NestedRecord(j.getNestedunion match {
         case null => None
-        case _ => Some(UnionRecord(j.getNestedunion.getBlah.toString))
+        case _ => Some(UnionRecord.metadata.fromAvro(j.getNestedunion))
       })
     }
   }

--- a/avrohugger-core/src/test/expected/scavro/test/model/ComplexExternalDependency.scala
+++ b/avrohugger-core/src/test/expected/scavro/test/model/ComplexExternalDependency.scala
@@ -18,14 +18,7 @@ import test.{ComplexExternalDependency => JComplexExternalDependency}
 case class ComplexExternalDependency(nestedrecord: NestedRecord) extends AvroSerializeable {
   type J = JComplexExternalDependency
   override def toAvro: JComplexExternalDependency = {
-    new JComplexExternalDependency(nestedrecord match {
-      case NestedRecord(nestedunion) => new JNestedRecord(nestedunion match {
-        case Some(x) => x match {
-          case UnionRecord(blah) => new JUnionRecord(blah)
-        }
-        case None => null
-      })
-    })
+    new JComplexExternalDependency(nestedrecord.toAvro)
   }
 }
 
@@ -37,10 +30,7 @@ object ComplexExternalDependency {
     override val avroClass: Class[JComplexExternalDependency] = classOf[JComplexExternalDependency]
     override val schema: Schema = JComplexExternalDependency.getClassSchema()
     override val fromAvro: (JComplexExternalDependency) => ComplexExternalDependency = {
-      (j: JComplexExternalDependency) => ComplexExternalDependency(NestedRecord(j.getNestedrecord.getNestedunion match {
-        case null => None
-        case _ => Some(UnionRecord(j.getNestedrecord.getNestedunion.getBlah.toString))
-      }))
+      (j: JComplexExternalDependency) => ComplexExternalDependency(NestedRecord.metadata.fromAvro(j.getNestedrecord))
     }
   }
 }

--- a/avrohugger-core/src/test/scala/scavro/ScavroStringToStringsSpec.scala
+++ b/avrohugger-core/src/test/scala/scavro/ScavroStringToStringsSpec.scala
@@ -2,12 +2,7 @@ package avrohugger
 package test
 package scavro
 
-import java.io.File
-
-import avrohugger.Generator
 import avrohugger.format.Scavro
-import avrohugger.StringGenerator
-
 import org.specs2._
 
 class ScavroStringToStringsSpec extends mutable.Specification {
@@ -148,6 +143,16 @@ class ScavroStringToStringsSpec extends mutable.Specification {
 
       val expected = util.Util.readFile("avrohugger-core/src/test/expected/scavro/example/idl/model/Defaults.scala")
       source === expected
+    }
+
+    "17. correctly generate with messy schema" in {
+      val inputString = util.Util.readFile("avrohugger-core/src/test/avro/clash.avsc")
+      val gen = new Generator(Scavro)
+      val List(source0, source1, source2) = gen.stringToStrings(inputString)
+
+      source0 === util.Util.readFile("avrohugger-core/src/test/expected/scavro/example/model/ClashInner.scala")
+      source1 === util.Util.readFile("avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala")
+      source2 === util.Util.readFile("avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala")
     }
 
     import util.GlobalTests

--- a/avrohugger-tools/src/test/compiler/output-scavro/avro/examples/baseball/Player.scala
+++ b/avrohugger-tools/src/test/compiler/output-scavro/avro/examples/baseball/Player.scala
@@ -15,9 +15,7 @@ case class Player(number: Int, first_name: String, last_name: String, nicknames:
     new JPlayer(number, first_name, last_name, {
       val array: java.util.List[JNickname] = new java.util.ArrayList[JNickname]
       nicknames foreach { element =>
-        array.add(element match {
-          case Nickname(name) => new JNickname(name)
-        })
+        array.add(element.toAvro)
       }
       array
     })
@@ -33,7 +31,7 @@ object Player {
     override val schema: Schema = JPlayer.getClassSchema()
     override val fromAvro: (JPlayer) => Player = {
       (j: JPlayer) => Player(j.getNumber.toInt, j.getFirstName.toString, j.getLastName.toString, Array((j.getNicknames.asScala: _*)) map { x =>
-        Nickname(x.getName.toString)
+        Nickname.metadata.fromAvro(x)
       })
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object BuildSettings {
 
   val buildSettings = Defaults.defaultSettings ++ scriptedSettings ++ Seq(
     organization := "com.julianpeeters",
-    version := "0.16.0",
+    version := "0.17.0-SNAPSHOT",
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
     scalaVersion := "2.11.8",
     crossScalaVersions := Seq("2.10.6", scalaVersion.value),


### PR DESCRIPTION
I realized that the current scavro implementation fails on some nested name clashes so I added a example test case showing the failure and a patch that uses a different approach in converting nested records by just calling toAvro/fromAvro of the nested record avoiding the clash.