### PR TITLE
Support for `union` types

### DIFF
--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -3,21 +3,36 @@ package format
 package standard
 
 import avrohugger.format.abstractions.Importer
-import avrohugger.input.DependencyInspector._
-import avrohugger.input.NestedSchemaExtractor._
 import avrohugger.matchers.TypeMatcher
 import avrohugger.stores.SchemaStore
-
-import collection.JavaConverters._
-
-import org.apache.avro.{ Protocol, Schema }
 import org.apache.avro.Schema.Type.RECORD
-
+import org.apache.avro.{Protocol, Schema}
 import treehugger.forest._
 import definitions._
 import treehuggerDSL._
 
+import scala.collection.JavaConverters._
+
 object StandardImporter extends Importer {
+
+  /**
+    * Shapeless representations of Coproduct are by default only active when `union`
+    * is defined with more than two types or three types where one of them is nullable.
+    * Otherwise the default values require no special imports
+    * since they are codegen in terms of [[Option]] and [[Either]]
+    */
+  private[this] def requiresShapelessImports(schema: Schema): Boolean = {
+    val fields = schema.getFields.asScala
+    val isUnion: Schema.Field => Boolean = _.schema().getType == Schema.Type.UNION
+    val unionContainsNull: Schema.Field => Boolean = _.schema().getTypes.asScala.exists(_.getType == Schema.Type.NULL)
+    val containsUnion = fields.exists(isUnion)
+    val containsNull = fields.filter(isUnion).exists(unionContainsNull)
+    val innerFieldsSize = fields.find(isUnion).map(_.schema().getTypes.size()).getOrElse(0)
+    val requiresImports =
+      containsUnion &&
+        ((innerFieldsSize > 2 && !containsNull) || (innerFieldsSize > 3 && containsNull))
+    requiresImports
+  }
 
   def getImports(
     schemaOrProtocol: Either[Schema, Protocol],
@@ -34,15 +49,12 @@ object StandardImporter extends Importer {
 
     schemaOrProtocol match {
       case Left(schema) => {
-        val includeShapeless =
-          schema.getFields.asScala.exists(_.schema().getType == Schema.Type.UNION)
-        if (schema.getType == RECORD && includeShapeless) shapelessImport :: deps
+        if (schema.getType == RECORD && requiresShapelessImports(schema)) shapelessImport :: deps
         else deps
       }
       case Right(protocol) => {
         val types = protocol.getTypes.asScala.toList
-        val includeShapeless = types.exists(_.getFields.asScala.exists(_.schema().getType == Schema.Type.UNION))
-        if (includeShapeless) shapelessImport :: deps
+        if (types.exists(requiresShapelessImports)) shapelessImport :: deps
         else deps
       }
     }

--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -54,7 +54,7 @@ object StandardImporter extends Importer {
       }
       case Right(protocol) => {
         val types = protocol.getTypes.asScala.toList
-        if (types.exists(requiresShapelessImports)) shapelessImport :: deps
+        if (types.exists(s => s.getType == RECORD && requiresShapelessImports(s))) shapelessImport :: deps
         else deps
       }
     }

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -39,8 +39,6 @@ object StandardCaseClassTree {
       PARAM(fieldName, fieldType) := defaultValue
     })
 
-    println(params)
-
     // There could be base traits, flags, or both, and could have no fields
     val caseClassDef = (maybeBaseTrait, maybeFlags) match {
       case (Some(baseTrait), Some(flags)) => {

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -39,6 +39,8 @@ object StandardCaseClassTree {
       PARAM(fieldName, fieldType) := defaultValue
     })
 
+    println(params)
+
     // There could be base traits, flags, or both, and could have no fields
     val caseClassDef = (maybeBaseTrait, maybeFlags) match {
       case (Some(baseTrait), Some(flags)) => {

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -1,9 +1,6 @@
 package avrohugger
 package matchers
 
-import java.io.ByteArrayOutputStream
-import java.nio.charset.StandardCharsets
-
 import stores.ClassStore
 import treehugger.forest._
 import treehuggerDSL._

--- a/avrohugger-core/src/test/avro/unions_with_coproduct.avdl
+++ b/avrohugger-core/src/test/avro/unions_with_coproduct.avdl
@@ -1,0 +1,60 @@
+@namespace("example.idl")
+protocol WithShapelessCoproduct {
+
+  record Event1 {
+  }
+
+  record Event2 {
+  }
+
+  record Event3 {
+  }
+
+  record Event4 {
+  }
+
+  record ShouldRenderAsOption {
+    union { null, Event1 } value;
+  }
+
+  record ShouldRenderAsOption2 {
+    union { Event1, null } value;
+  }
+
+  record ShouldRenderAsOptionEither {
+    union { null, Event1, Event2 } value;
+  }
+
+  record ShouldRenderAsOptionEither2 {
+    union { Event1, null, Event2 } value;
+  }
+
+  record ShouldRenderAsOptionEither3 {
+    union { Event1, Event2, null } value;
+  }
+
+  record ShouldRenderAsOptionCoproduct {
+    union { null, Event1, Event2, Event3 } value;
+  }
+
+  record ShouldRenderAsOptionCoproduct2 {
+    union { Event1, Event2, Event3, null } value;
+  }
+
+  record ShouldRenderAsOptionCoproduct3 {
+    union { Event1, Event2, null, Event3 } value;
+  }
+
+  record ShouldRenderAsEither {
+    union { Event1, Event2 } value;
+  }
+
+  record ShouldRenderAsCoproduct {
+    union { Event1, Event2, Event3, Event4 } value;
+  }
+
+  record ShouldRenderAsCoproduct2 {
+    union { Event1, Event2, Event3, Event4 } value;
+  }
+
+}

--- a/avrohugger-core/src/test/avro/unions_without_coproduct.avdl
+++ b/avrohugger-core/src/test/avro/unions_without_coproduct.avdl
@@ -1,0 +1,41 @@
+@namespace("example.idl")
+protocol WithoutShapelessCoproduct {
+
+  record Event1 {
+  }
+
+  record Event2 {
+  }
+
+  record Event3 {
+  }
+
+  record Event4 {
+  }
+
+  record ShouldRenderAsOption {
+    union { null, Event1 } value;
+  }
+
+  record ShouldRenderAsOption2 {
+    union { Event1, null } value;
+  }
+
+  record ShouldRenderAsOptionEither {
+    union { null, Event1, Event2 } value;
+  }
+
+  record ShouldRenderAsOptionEither2 {
+    union { Event1, null, Event2 } value;
+  }
+
+  record ShouldRenderAsOptionEither3 {
+    union { Event1, Event2, null } value;
+  }
+
+  record ShouldRenderAsEither {
+    union { Event1, Event2 } value;
+  }
+
+
+}

--- a/avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala
@@ -1,0 +1,36 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import shapeless.{:+:, CNil}
+
+sealed trait WithShapelessCoproduct extends Product with Serializable
+
+final case class Event1() extends WithShapelessCoproduct
+
+final case class Event2() extends WithShapelessCoproduct
+
+final case class Event3() extends WithShapelessCoproduct
+
+final case class Event4() extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOption(value: Option[Event1]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOption2(value: Option[Event1]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOptionEither(value: Option[Either[Event1, Event2]]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOptionEither2(value: Option[Either[Event1, Event2]]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOptionEither3(value: Option[Either[Event1, Event2]]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsEither(value: Either[Event1, Event2]) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil) extends WithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct2(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil) extends WithShapelessCoproduct

--- a/avrohugger-core/src/test/expected/standard/example/idl/WithoutShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/WithoutShapelessCoproduct.scala
@@ -1,0 +1,24 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+sealed trait WithoutShapelessCoproduct extends Product with Serializable
+
+final case class Event1() extends WithoutShapelessCoproduct
+
+final case class Event2() extends WithoutShapelessCoproduct
+
+final case class Event3() extends WithoutShapelessCoproduct
+
+final case class Event4() extends WithoutShapelessCoproduct
+
+final case class ShouldRenderAsOption(value: Option[Event1]) extends WithoutShapelessCoproduct
+
+final case class ShouldRenderAsOption2(value: Option[Event1]) extends WithoutShapelessCoproduct
+
+final case class ShouldRenderAsOptionEither(value: Option[Either[Event1, Event2]]) extends WithoutShapelessCoproduct
+
+final case class ShouldRenderAsOptionEither2(value: Option[Either[Event1, Event2]]) extends WithoutShapelessCoproduct
+
+final case class ShouldRenderAsOptionEither3(value: Option[Either[Event1, Event2]]) extends WithoutShapelessCoproduct
+
+final case class ShouldRenderAsEither(value: Either[Event1, Event2]) extends WithoutShapelessCoproduct

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -30,6 +30,8 @@ class StandardFileToFileSpec extends Specification {
       correctly generate records depending on others defined in a different- and same-namespaced AVDL and AVSC $e14
       correctly generate an empty case class definition $e15
       correctly generate default values $e16
+      correctly generate union values without shapeless Coproduct $e17
+      correctly generate union values with shapeless Coproduct $e18
   """
   
   // tests specific to fileToX
@@ -241,6 +243,28 @@ class StandardFileToFileSpec extends Specification {
     val adt = util.Util.readFile("target/generated-sources/standard/example/idl/Defaults.scala")
     
     adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/Defaults.scala")
+  }
+
+  def e17 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/unions_without_coproduct.avdl")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val adt = util.Util.readFile("target/generated-sources/standard/example/idl/WithoutShapelessCoproduct.scala")
+
+    adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/WithoutShapelessCoproduct.scala")
+  }
+
+  def e18 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/unions_with_coproduct.avdl")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val adt = util.Util.readFile("target/generated-sources/standard/example/idl/WithShapelessCoproduct.scala")
+
+    adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala")
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,14 @@ lazy val avroVersion = "1.7.7"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "0.17.0",
+  version := "0.17.0-SNAPSHOT",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.10.6", "2.11.11", scalaVersion.value),
   resolvers += Resolver.typesafeIvyRepo("releases"),
   libraryDependencies += "org.apache.avro" % "avro" % avroVersion,
   libraryDependencies += "org.apache.avro" % "avro-compiler" % avroVersion,
+  libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.2" % Test,
   // for implementing SpecificRecord from standard case class definitions
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   libraryDependencies := {

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ lazy val commonSettings = Seq(
   resolvers += Resolver.typesafeIvyRepo("releases"),
   libraryDependencies += "org.apache.avro" % "avro" % avroVersion,
   libraryDependencies += "org.apache.avro" % "avro-compiler" % avroVersion,
-  libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.2" % Test,
   // for implementing SpecificRecord from standard case class definitions
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   libraryDependencies := {


### PR DESCRIPTION
Fixes #50 

This PR introduces support for `union` types of arbitrary arity when generating scala from avro schemas and protocols.

Handles unions with the following type translations:
```
union:null,T => Option[T]
union:L,R => Either[L, R]
union:A,B,C => A :+: B :+: C :+: CNil
union:null,L,R => Option[Either[L, R]]
union:null,A,B,C => Option[A :+: B :+: C :+: CNil]
```

For the `shapeless.Coproduct` cases an `import` strategy has been introduced in order to include `import shapeless.{:+:, CNil}` in the imports so the codegen typechecks accordingly.
 
If a `null` is found at any position in the `union` the entire type is wrapped in Option and the `null` type removed from the sum type. This is because the avro spec is ambiguous about this and does not necesarilly disregard `null` types in other positions that is not the first one.

https://avro.apache.org/docs/1.8.1/spec.html#Unions
> Note that when a default value is specified for a record field whose type is a union, the type of the default value must match the first element of the union. Thus, for unions containing "null", the "null" is ***usually*** listed first, since the default value of such unions is typically null.

This PR includes 2 test cases with `.avdl` and expected generated `.scala` files for all the cases mentioned above. 

Cheers! :beers: 