### PR TITLE
Allow default params for unions and opt-in setting to generate all unions as shapeless Coproduct

### DIFF
--- a/avrohugger-core/src/main/scala/Generator.scala
+++ b/avrohugger-core/src/main/scala/Generator.scala
@@ -2,13 +2,13 @@ package avrohugger
 
 import avrohugger.format.abstractions.SourceFormat
 import avrohugger.format._
-import avrohugger.input.parsers.{ FileInputParser, StringInputParser}
+import avrohugger.input.parsers.{FileInputParser, StringInputParser}
 import avrohugger.matchers.TypeMatcher
-import avrohugger.stores.{ ClassStore, SchemaStore }
-
-import org.apache.avro.{ Protocol, Schema }
-
+import avrohugger.stores.{ClassStore, SchemaStore}
+import org.apache.avro.{Protocol, Schema}
 import java.io.File
+
+import format.standard._
 
 // Unable to overload this class' methods because outDir uses a default value
 class Generator(format: SourceFormat,
@@ -16,7 +16,7 @@ class Generator(format: SourceFormat,
                 avroScalaCustomNamespace: Map[String, String] = Map.empty,
                 avroScalaCustomEnumStyle: Map[String, String] = Map.empty,
                 restrictedFieldNumber: Boolean = false,
-                unionsAsShapelessCoproduct: Boolean = false) {
+                standardUnionStyle: UnionStyle = Default) {
 
   val sourceFormat = format
   val defaultOutputDir = "target/generated-sources"
@@ -25,7 +25,7 @@ class Generator(format: SourceFormat,
   lazy val schemaParser = new Schema.Parser
   val classStore = new ClassStore
   val schemaStore = new SchemaStore
-  val typeMatcher = new TypeMatcher(unionsAsShapelessCoproduct)
+  val typeMatcher = new TypeMatcher(standardUnionStyle)
 
   // update format defaults
   format match {

--- a/avrohugger-core/src/main/scala/Generator.scala
+++ b/avrohugger-core/src/main/scala/Generator.scala
@@ -1,7 +1,7 @@
 package avrohugger
 
 import avrohugger.format.abstractions.SourceFormat
-import avrohugger.format.{ Scavro, SpecificRecord }
+import avrohugger.format._
 import avrohugger.input.parsers.{ FileInputParser, StringInputParser}
 import avrohugger.matchers.TypeMatcher
 import avrohugger.stores.{ ClassStore, SchemaStore }
@@ -15,7 +15,8 @@ class Generator(format: SourceFormat,
                 avroScalaCustomTypes: Map[String, Class[_]] = Map.empty,
                 avroScalaCustomNamespace: Map[String, String] = Map.empty,
                 avroScalaCustomEnumStyle: Map[String, String] = Map.empty,
-                restrictedFieldNumber: Boolean = false) {
+                restrictedFieldNumber: Boolean = false,
+                unionsAsShapelessCoproduct: Boolean = false) {
 
   val sourceFormat = format
   val defaultOutputDir = "target/generated-sources"
@@ -24,7 +25,7 @@ class Generator(format: SourceFormat,
   lazy val schemaParser = new Schema.Parser
   val classStore = new ClassStore
   val schemaStore = new SchemaStore
-  val typeMatcher = new TypeMatcher
+  val typeMatcher = new TypeMatcher(unionsAsShapelessCoproduct)
 
   // update format defaults
   format match {

--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -40,7 +40,7 @@ object StandardImporter extends Importer {
     schemaStore: SchemaStore,
     typeMatcher: TypeMatcher): List[Import] = {
 
-    val shapelessCopSymbolsImport = RootClass.newClass("shapeless.{:+:, CNil}")
+    val shapelessCopSymbolsImport = RootClass.newClass("shapeless.{:+:, CNil, Coproduct}")
     val shapelessImport = IMPORT(shapelessCopSymbolsImport)
 
     val topLevelSchemas = getTopLevelSchemas(schemaOrProtocol, schemaStore)

--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -21,7 +21,7 @@ object StandardImporter extends Importer {
     * Otherwise the default values require no special imports
     * since they are codegen in terms of [[Option]] and [[Either]]
     */
-  private[this] def requiresShapelessImports(schema: Schema): Boolean = {
+  private[this] def requiresShapelessImports(schema: Schema, typeMatcher: TypeMatcher): Boolean = typeMatcher.unionsAsShapelessCoproduct || {
     val fields = schema.getFields.asScala
     val isUnion: Schema.Field => Boolean = _.schema().getType == Schema.Type.UNION
     val unionContainsNull: Schema.Field => Boolean = _.schema().getTypes.asScala.exists(_.getType == Schema.Type.NULL)
@@ -49,12 +49,12 @@ object StandardImporter extends Importer {
 
     schemaOrProtocol match {
       case Left(schema) => {
-        if (schema.getType == RECORD && requiresShapelessImports(schema)) shapelessImport :: deps
+        if (schema.getType == RECORD && requiresShapelessImports(schema, typeMatcher)) shapelessImport :: deps
         else deps
       }
       case Right(protocol) => {
         val types = protocol.getTypes.asScala.toList
-        if (types.exists(s => s.getType == RECORD && requiresShapelessImports(s))) shapelessImport :: deps
+        if (types.exists(s => s.getType == RECORD && requiresShapelessImports(s, typeMatcher))) shapelessImport :: deps
         else deps
       }
     }

--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -47,6 +47,7 @@ object StandardImporter extends Importer {
     val recordSchemas = getRecordSchemas(topLevelSchemas)
     val deps = getRecordImports(recordSchemas, currentNamespace, typeMatcher)
 
+
     schemaOrProtocol match {
       case Left(schema) => {
         if (schema.getType == RECORD && requiresShapelessImports(schema, typeMatcher)) shapelessImport :: deps

--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -21,7 +21,7 @@ object StandardImporter extends Importer {
     * Otherwise the default values require no special imports
     * since they are codegen in terms of [[Option]] and [[Either]]
     */
-  private[this] def requiresShapelessImports(schema: Schema, typeMatcher: TypeMatcher): Boolean = typeMatcher.unionsAsShapelessCoproduct || {
+  private[this] def requiresShapelessImports(schema: Schema, typeMatcher: TypeMatcher): Boolean = typeMatcher.standardUnionStyle == ShapelessCoproduct || {
     val fields = schema.getFields.asScala
     val isUnion: Schema.Field => Boolean = _.schema().getType == Schema.Type.UNION
     val unionContainsNull: Schema.Field => Boolean = _.schema().getTypes.asScala.exists(_.getType == Schema.Type.NULL)

--- a/avrohugger-core/src/main/scala/format/standard/StandardUnionStyle.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardUnionStyle.scala
@@ -1,0 +1,7 @@
+package avrohugger
+package format
+package standard
+
+sealed abstract class UnionStyle extends Product with Serializable
+case object Default extends UnionStyle
+case object ShapelessCoproduct extends UnionStyle

--- a/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
@@ -1,6 +1,7 @@
 package avrohugger
 package matchers
 
+import avrohugger.format.standard.{Default, ShapelessCoproduct}
 import treehugger.forest._
 import definitions._
 import treehuggerDSL._
@@ -120,9 +121,10 @@ object DefaultValueMatcher {
             })
     }
 
-    def matchedTree =
-      if (typeMatcher.unionsAsShapelessCoproduct) unionsAsShapelessCoproductStrategy
-      else unionsArityStrategy
+    def matchedTree = typeMatcher.standardUnionStyle match {
+      case Default => unionsArityStrategy
+      case ShapelessCoproduct => unionsAsShapelessCoproductStrategy
+    }
 
     node match {
       case `nullNode` => NONE

--- a/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
@@ -120,7 +120,7 @@ object DefaultValueMatcher {
             })
     }
 
-    val matchedTree =
+    def matchedTree =
       if (typeMatcher.unionsAsShapelessCoproduct) unionsAsShapelessCoproductStrategy
       else unionsArityStrategy
 

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -52,11 +52,6 @@ class TypeMatcher(val unionsAsShapelessCoproduct: Boolean = false) {
     val _ = customEnumStyleMap += customEnumStyleMapEntry
   }
 
-  // updates the enum style map map to allow for avro to java or scala mappings
-  def updateCustomUnionStyleMap(customUnionStyleMapEntry: (String, String)) {
-    val _ = customUnionStyleMap += customUnionStyleMapEntry
-  }
-
   def toScalaType(
     classStore: ClassStore,
     namespace: Option[String],

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -9,12 +9,13 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.{Type => AvroType}
 import java.util.concurrent.ConcurrentHashMap
 
+import avrohugger.format.standard.{Default, ShapelessCoproduct, UnionStyle}
 import treehugger.forest
 
 import scala.collection.convert.Wrappers.JConcurrentMapWrapper
 import scala.collection.JavaConverters._
 
-class TypeMatcher(val unionsAsShapelessCoproduct: Boolean = false) {
+class TypeMatcher(val standardUnionStyle: UnionStyle = Default) {
 
   // holds user-defined custom type mappings, e.g. ("array"->classOf[Array[_]])
   val customTypeMap: scala.collection.concurrent.Map[String, Class[_]] = {
@@ -146,9 +147,10 @@ class TypeMatcher(val unionsAsShapelessCoproduct: Boolean = false) {
         unionsAsShapelessCoproductStrategy
     }
 
-    val matchedType =
-      if (unionsAsShapelessCoproduct) unionsAsShapelessCoproductStrategy
-      else unionsArityStrategy
+    val matchedType = standardUnionStyle match {
+      case Default => unionsArityStrategy
+      case ShapelessCoproduct => unionsAsShapelessCoproductStrategy
+    }
 
     if (includesNull) optionType(matchedType) else matchedType
   }

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -14,7 +14,7 @@ import treehugger.forest
 import scala.collection.convert.Wrappers.JConcurrentMapWrapper
 import scala.collection.JavaConverters._
 
-class TypeMatcher(unionsAsShapelessCoproduct: Boolean = false) {
+class TypeMatcher(val unionsAsShapelessCoproduct: Boolean = false) {
 
   // holds user-defined custom type mappings, e.g. ("array"->classOf[Array[_]])
   val customTypeMap: scala.collection.concurrent.Map[String, Class[_]] = {

--- a/avrohugger-core/src/test/avro/all_unions_as_coproduct.avdl
+++ b/avrohugger-core/src/test/avro/all_unions_as_coproduct.avdl
@@ -1,0 +1,60 @@
+@namespace("example.idl")
+protocol AllUnionsWithShapelessCoproduct {
+
+  record Event1 {
+  }
+
+  record Event2 {
+  }
+
+  record Event3 {
+  }
+
+  record Event4 {
+  }
+
+  record ShouldRenderAsCoproduct {
+    union { null, Event1 } value;
+  }
+
+  record ShouldRenderAsCoproduct2 {
+    union { Event1, null } value;
+  }
+
+  record ShouldRenderAsCoproduct3 {
+    union { null, Event1, Event2 } value;
+  }
+
+  record ShouldRenderAsCoproduct4 {
+    union { Event1, null, Event2 } value;
+  }
+
+  record ShouldRenderAsCoproduct5 {
+    union { Event1, Event2, null } value;
+  }
+
+  record ShouldRenderAsCoproduct6 {
+    union { null, Event1, Event2, Event3 } value;
+  }
+
+  record ShouldRenderAsCoproduct7 {
+    union { Event1, Event2, Event3, null } value;
+  }
+
+  record ShouldRenderAsCoproduct8 {
+    union { Event1, Event2, null, Event3 } value;
+  }
+
+  record ShouldRenderAsCoproduct9 {
+    union { Event1, Event2 } value;
+  }
+
+  record ShouldRenderAsCoproduct10 {
+    union { Event1, Event2, Event3, Event4 } value;
+  }
+
+  record ShouldRenderAsCoproduct11 {
+    union { Event1, Event2, Event3, Event4 } value;
+  }
+
+}

--- a/avrohugger-core/src/test/avro/unions_default_param_values.avdl
+++ b/avrohugger-core/src/test/avro/unions_default_param_values.avdl
@@ -1,0 +1,90 @@
+@namespace("example.idl")
+protocol UnionsDefaultParamsValues {
+
+  record Event1 {
+    int index;
+  }
+
+  record Event2 {
+  }
+
+  record Event3 {
+  }
+
+  record Event4 {
+    int index;
+  }
+
+  record Event5 {
+  }
+
+  record Event6 {
+  }
+
+  record Event7 {
+    int index;
+  }
+
+  record Event8 {
+  }
+
+  record Event9 {
+  }
+
+  record ShouldRenderAsOption {
+    union { null, Event1 } value = null;
+  }
+
+  record ShouldRenderAsOption2 {
+    union { Event1, null } value = { "index" : 0 };
+  }
+
+  record ShouldRenderAsOptionEither {
+    union { null, Event1, Event2 } value = null;
+  }
+
+  record ShouldRenderAsOptionEither2 {
+    union { Event1, null, Event2 } value = { "index" : 1 };
+  }
+
+  record ShouldRenderAsOptionEither3 {
+    union { Event1, Event2, null } value = { "index" : 2 };
+  }
+
+  record ShouldRenderAsOptionCoproduct {
+    union { null, Event1, Event2, Event3 } value = null;
+  }
+
+  record ShouldRenderAsOptionCoproduct2 {
+    union { Event1, Event2, Event3, null } value = { "index" : 3 };
+  }
+
+  record ShouldRenderAsOptionCoproduct3 {
+    union { Event1, Event2, null, Event3 } value= { "index" : 4 };
+  }
+
+  record ShouldRenderAsEither {
+    union { Event1, Event2 } value = { "index" : 5 };
+  }
+
+  record ShouldRenderAsCoproduct {
+    union { Event1, Event2, Event3, Event4 } value = { "index" : 6 };
+  }
+
+  record CopX {
+    union { Event1, Event2, Event3 } value = { "index" : 7 };
+  }
+
+  record CopY {
+    union { Event4, Event5, Event6 } value = { "index" : 8 };
+  }
+
+  record CopZ {
+    union { Event7, Event8, Event9 } value = { "index" : 9 };
+  }
+
+  record ShouldRenderAsCoproductOfCoproduct {
+    union { CopX, CopY, CopZ } value = { "value" : { "index" : 10 }};
+  }
+
+}

--- a/avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithShapelessCoproduct.scala
@@ -1,0 +1,36 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import shapeless.{:+:, CNil, Coproduct}
+
+sealed trait AllUnionsWithShapelessCoproduct extends Product with Serializable
+
+final case class Event1() extends AllUnionsWithShapelessCoproduct
+
+final case class Event2() extends AllUnionsWithShapelessCoproduct
+
+final case class Event3() extends AllUnionsWithShapelessCoproduct
+
+final case class Event4() extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct(value: Option[Event1 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct2(value: Option[Event1 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct3(value: Option[Event1 :+: Event2 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct4(value: Option[Event1 :+: Event2 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct5(value: Option[Event1 :+: Event2 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct6(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct7(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct8(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct9(value: Event1 :+: Event2 :+: CNil) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct10(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil) extends AllUnionsWithShapelessCoproduct
+
+final case class ShouldRenderAsCoproduct11(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil) extends AllUnionsWithShapelessCoproduct

--- a/avrohugger-core/src/test/expected/standard/example/idl/UnionsDefaultParamsValues.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/UnionsDefaultParamsValues.scala
@@ -23,15 +23,15 @@ final case class Event8() extends UnionsDefaultParamsValues
 
 final case class Event9() extends UnionsDefaultParamsValues
 
-final case class ShouldRenderAsOption(value: Option[Event1 :+: CNil] = None) extends UnionsDefaultParamsValues
+final case class ShouldRenderAsOption(value: Option[Event1] = None) extends UnionsDefaultParamsValues
 
-final case class ShouldRenderAsOption2(value: Option[Event1 :+: CNil] = Some(new Event1(0))) extends UnionsDefaultParamsValues
+final case class ShouldRenderAsOption2(value: Option[Event1] = Some(new Event1(0))) extends UnionsDefaultParamsValues
 
-final case class ShouldRenderAsOptionEither(value: Option[Event1 :+: Event2 :+: CNil] = None) extends UnionsDefaultParamsValues
+final case class ShouldRenderAsOptionEither(value: Option[Either[Event1, Event2]] = None) extends UnionsDefaultParamsValues
 
-final case class ShouldRenderAsOptionEither2(value: Option[Event1 :+: Event2 :+: CNil] = Some(Left(new Event1(1)))) extends UnionsDefaultParamsValues
+final case class ShouldRenderAsOptionEither2(value: Option[Either[Event1, Event2]] = Some(Left(new Event1(1)))) extends UnionsDefaultParamsValues
 
-final case class ShouldRenderAsOptionEither3(value: Option[Event1 :+: Event2 :+: CNil] = Some(Left(new Event1(2)))) extends UnionsDefaultParamsValues
+final case class ShouldRenderAsOptionEither3(value: Option[Either[Event1, Event2]] = Some(Left(new Event1(2)))) extends UnionsDefaultParamsValues
 
 final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = None) extends UnionsDefaultParamsValues
 
@@ -39,7 +39,7 @@ final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 
 
 final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(4)))) extends UnionsDefaultParamsValues
 
-final case class ShouldRenderAsEither(value: Event1 :+: Event2 :+: CNil = Left(new Event1(5))) extends UnionsDefaultParamsValues
+final case class ShouldRenderAsEither(value: Either[Event1, Event2] = Left(new Event1(5))) extends UnionsDefaultParamsValues
 
 final case class ShouldRenderAsCoproduct(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1(6))) extends UnionsDefaultParamsValues
 

--- a/avrohugger-core/src/test/expected/standard/example/idl/UnionsDefaultParamsValues.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/UnionsDefaultParamsValues.scala
@@ -1,0 +1,52 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import shapeless.{:+:, CNil, Coproduct}
+
+sealed trait UnionsDefaultParamsValues extends Product with Serializable
+
+final case class Event1(index: Int) extends UnionsDefaultParamsValues
+
+final case class Event2() extends UnionsDefaultParamsValues
+
+final case class Event3() extends UnionsDefaultParamsValues
+
+final case class Event4(index: Int) extends UnionsDefaultParamsValues
+
+final case class Event5() extends UnionsDefaultParamsValues
+
+final case class Event6() extends UnionsDefaultParamsValues
+
+final case class Event7(index: Int) extends UnionsDefaultParamsValues
+
+final case class Event8() extends UnionsDefaultParamsValues
+
+final case class Event9() extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOption(value: Option[Event1 :+: CNil] = None) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOption2(value: Option[Event1 :+: CNil] = Some(new Event1(0))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOptionEither(value: Option[Event1 :+: Event2 :+: CNil] = None) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOptionEither2(value: Option[Event1 :+: Event2 :+: CNil] = Some(Left(new Event1(1)))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOptionEither3(value: Option[Event1 :+: Event2 :+: CNil] = Some(Left(new Event1(2)))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = None) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(3)))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(4)))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsEither(value: Event1 :+: Event2 :+: CNil = Left(new Event1(5))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsCoproduct(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1(6))) extends UnionsDefaultParamsValues
+
+final case class CopX(value: Event1 :+: Event2 :+: Event3 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(7))) extends UnionsDefaultParamsValues
+
+final case class CopY(value: Event4 :+: Event5 :+: Event6 :+: CNil = Coproduct[Event4 :+: Event5 :+: Event6 :+: CNil](new Event4(8))) extends UnionsDefaultParamsValues
+
+final case class CopZ(value: Event7 :+: Event8 :+: Event9 :+: CNil = Coproduct[Event7 :+: Event8 :+: Event9 :+: CNil](new Event7(9))) extends UnionsDefaultParamsValues
+
+final case class ShouldRenderAsCoproductOfCoproduct(value: CopX :+: CopY :+: CopZ :+: CNil = Coproduct[CopX :+: CopY :+: CopZ :+: CNil](new CopX(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(10))))) extends UnionsDefaultParamsValues

--- a/avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala
@@ -1,7 +1,7 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-import shapeless.{:+:, CNil}
+import shapeless.{:+:, CNil, Coproduct}
 
 sealed trait WithShapelessCoproduct extends Product with Serializable
 

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -32,6 +32,7 @@ class StandardFileToFileSpec extends Specification {
       correctly generate default values $e16
       correctly generate union values without shapeless Coproduct $e17
       correctly generate union values with shapeless Coproduct $e18
+      correctly generate all union values with shapeless Coproduct when instructed by generator $e19
   """
   
   // tests specific to fileToX
@@ -265,6 +266,17 @@ class StandardFileToFileSpec extends Specification {
     val adt = util.Util.readFile("target/generated-sources/standard/example/idl/WithShapelessCoproduct.scala")
 
     adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala")
+  }
+
+  def e19 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/all_unions_as_coproduct.avdl")
+    val gen = new Generator(Standard, unionsAsShapelessCoproduct = true)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val adt = util.Util.readFile("target/generated-sources/standard/example/idl/AllUnionsWithShapelessCoproduct.scala")
+
+    adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithShapelessCoproduct.scala")
   }
 
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -6,6 +6,7 @@ import java.io.File
 
 import avrohugger._
 import avrohugger.format.Standard
+import avrohugger.format.standard.ShapelessCoproduct
 import org.specs2._
 
 class StandardFileToFileSpec extends Specification {
@@ -271,7 +272,7 @@ class StandardFileToFileSpec extends Specification {
 
   def e19 = {
     val infile = new java.io.File("avrohugger-core/src/test/avro/all_unions_as_coproduct.avdl")
-    val gen = new Generator(Standard, unionsAsShapelessCoproduct = true)
+    val gen = new Generator(Standard, standardUnionStyle = ShapelessCoproduct)
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(infile, outDir)
 

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -33,6 +33,7 @@ class StandardFileToFileSpec extends Specification {
       correctly generate union values without shapeless Coproduct $e17
       correctly generate union values with shapeless Coproduct $e18
       correctly generate all union values with shapeless Coproduct when instructed by generator $e19
+      correctly generate union default parameter values $e20
   """
   
   // tests specific to fileToX
@@ -277,6 +278,17 @@ class StandardFileToFileSpec extends Specification {
     val adt = util.Util.readFile("target/generated-sources/standard/example/idl/AllUnionsWithShapelessCoproduct.scala")
 
     adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithShapelessCoproduct.scala")
+  }
+
+  def e20 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/unions_default_param_values.avdl")
+    val gen = new Generator(Standard, unionsAsShapelessCoproduct = true)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val adt = util.Util.readFile("target/generated-sources/standard/example/idl/UnionsDefaultParamsValues.scala")
+
+    adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/UnionsDefaultParamsValues.scala")
   }
 
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -282,7 +282,7 @@ class StandardFileToFileSpec extends Specification {
 
   def e20 = {
     val infile = new java.io.File("avrohugger-core/src/test/avro/unions_default_param_values.avdl")
-    val gen = new Generator(Standard, unionsAsShapelessCoproduct = true)
+    val gen = new Generator(Standard)
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(infile, outDir)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val avroVersion = "1.7.7"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "0.18.0",
+  version := "0.18.0-SNAPSHOT",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.10.6", "2.11.11", scalaVersion.value),


### PR DESCRIPTION


- [x] Default parameter values for all union types
- [x] Opt-in setting to generate all `union` as `shapeless.Coproduct`
- [x] Codegen tests
- [x] scripted tests at https://github.com/julianpeeters/sbt-avrohugger/pull/46