### PR TITLE
Allow generate classes if two AVSC files contain equivalent common records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# IntelliJ specific
+.idea

--- a/avrohugger-core/src/test/avro/order.avsc
+++ b/avrohugger-core/src/test/avro/order.avsc
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "name": "Order",
+  "namespace": "com.same.element",
+  "doc": "For testing class generation for schemas that have common types",
+  "fields": [
+    {
+      "name": "user",
+      "type": {
+        "type": "record",
+        "name": "User",
+        "fields": [
+          {"name": "name", "type": "string"},
+          {"name": "favorite_number",  "type": ["int", "null"]},
+          {"name": "favorite_color", "type": ["string", "null"]}
+        ]
+      }
+    },
+    {
+      "name" : "id",
+      "type" : "int"
+    },
+    {
+      "name" : "orderTotal",
+      "type" : "double"
+    }
+  ]
+}

--- a/avrohugger-core/src/test/avro/userMonthlyReport.avsc
+++ b/avrohugger-core/src/test/avro/userMonthlyReport.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "MonthlyReport",
+  "namespace": "com.same.element",
+  "doc": "For testing class generation for schemas that have common types",
+  "fields": [
+    {
+      "name": "user",
+      "type": {
+        "type": "record",
+        "name": "User",
+        "fields": [
+          {"name": "name", "type": "string"},
+          {"name": "favorite_number",  "type": ["int", "null"]},
+          {"name": "favorite_color", "type": ["string", "null"]}
+        ]
+      }
+    },
+    {
+      "name" : "monthlySpend",
+      "type" : "double"
+    }
+  ]
+}

--- a/avrohugger-core/src/test/avro/userRedefinedMonthlyReport.avsc
+++ b/avrohugger-core/src/test/avro/userRedefinedMonthlyReport.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "MonthlyReport",
+  "namespace": "com.same.element",
+  "doc": "For testing class generation for schemas that have common types",
+  "fields": [
+    {
+      "name": "user",
+      "type": {
+        "type": "record",
+        "name": "User",
+        "fields": [
+          {"name": "name", "type": "string"},
+          {"name": "address",  "type": ["string", "null"]},
+          {"name": "city", "type": ["string", "null"]}
+        ]
+      }
+    },
+    {
+      "name" : "monthlySpend",
+      "type" : "double"
+    }
+  ]
+}


### PR DESCRIPTION
Avro allows to define common elements (records) that are shared between schemas, all is fine if you use AVDL files, but sadly if one uses schema registry then everything is smushed together in one AVSC file and now if your app is supposed to comsume data from two different sources that have schemas that contain some common elements then avrohugger fails to generate classes, this commit here is to allow class generation to work if those common elements are equivalent and fail if they are different.

Related to https://github.com/julianpeeters/avrohugger/issues/73