### PR TITLE
Support for `decimal` logical type.

### DIFF
--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -50,7 +50,6 @@ class TypeMatcher(
         case Schema.Type.STRING   => StringClass
         case Schema.Type.FIXED    => sys.error("FIXED datatype not yet supported")
         case Schema.Type.BYTES    =>
-          println(s"decimal: ${schema.toString(true)}")
           Option(schema.getLogicalType) match {
             case Some(tpe) if tpe.getName == "decimal"  =>
               BigDecimalClass

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -50,6 +50,7 @@ class TypeMatcher(
         case Schema.Type.STRING   => StringClass
         case Schema.Type.FIXED    => sys.error("FIXED datatype not yet supported")
         case Schema.Type.BYTES    =>
+          println(s"decimal: ${schema.toString(true)}")
           Option(schema.getLogicalType) match {
             case Some(tpe) if tpe.getName == "decimal"  =>
               BigDecimalClass

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -49,7 +49,13 @@ class TypeMatcher(
         case Schema.Type.NULL     => NullClass
         case Schema.Type.STRING   => StringClass
         case Schema.Type.FIXED    => sys.error("FIXED datatype not yet supported")
-        case Schema.Type.BYTES    => TYPE_ARRAY(ByteClass)
+        case Schema.Type.BYTES    =>
+          Option(schema.getLogicalType) match {
+            case Some(tpe) if tpe.getName == "decimal"  =>
+              BigDecimalClass
+            case _ =>
+              TYPE_ARRAY(ByteClass)
+          }
         case Schema.Type.RECORD   => classStore.generatedClasses(schema)
         case Schema.Type.ENUM     => CustomTypeMatcher.checkCustomEnumType(avroScalaTypes.enum, classStore, schema)
         case Schema.Type.UNION    => {

--- a/avrohugger-core/src/test/avro/decimal.avdl
+++ b/avrohugger-core/src/test/avro/decimal.avdl
@@ -1,0 +1,10 @@
+@namespace("example.idl")
+
+protocol DecimalIDL {
+
+  record DecimalIdl {
+    decimal(9, 2) dec = 8888.88;
+    union {decimal(9, 2), null} maybeDec = 9999.99;
+  }
+
+}

--- a/avrohugger-core/src/test/avro/decimal.avpr
+++ b/avrohugger-core/src/test/avro/decimal.avpr
@@ -1,5 +1,5 @@
 {
-  "namespace": "example.proto",
+  "namespace": "example.decimal.proto",
   "protocol": "DecimalProtocol",
   "types": [
     {
@@ -8,7 +8,12 @@
       "fields": [
         {
           "name": "dec",
-          "type": "bytes",
+          "type": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 9,
+            "scale": 2
+          },
           "logicalType": "decimal",
           "precision": 9,
           "scale": 2

--- a/avrohugger-core/src/test/avro/decimal.avpr
+++ b/avrohugger-core/src/test/avro/decimal.avpr
@@ -1,0 +1,20 @@
+{
+  "namespace": "example.proto",
+  "protocol": "DecimalProtocol",
+  "types": [
+    {
+      "name": "DecimalPr",
+      "type": "record",
+      "fields": [
+        {
+          "name": "dec",
+          "type": "bytes",
+          "logicalType": "decimal",
+          "precision": 9,
+          "scale": 2
+        }
+      ]
+    }
+  ],
+  "messages": []
+}

--- a/avrohugger-core/src/test/avro/decimal.avsc
+++ b/avrohugger-core/src/test/avro/decimal.avsc
@@ -1,14 +1,16 @@
 {
-  "namespace": "example",
+  "namespace": "example.decimal",
   "type": "record",
   "name": "DecimalSc",
   "fields": [
     {
       "name": "data",
-      "type": "bytes",
-      "logicalType": "decimal",
-      "precision": 9,
-      "scale": 2
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 9,
+        "scale": 2
+      }
     }
   ]
 }

--- a/avrohugger-core/src/test/avro/decimal.avsc
+++ b/avrohugger-core/src/test/avro/decimal.avsc
@@ -1,0 +1,14 @@
+{
+  "namespace": "example",
+  "type": "record",
+  "name": "DecimalSc",
+  "fields": [
+    {
+      "name": "data",
+      "type": "bytes",
+      "logicalType": "decimal",
+      "precision": 9,
+      "scale": 2
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/standard/example/idl/DecimalIdl.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/DecimalIdl.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+case class DecimalIdl(dec: BigDecimal = scala.math.BigDecimal("8888.88"), maybeDec: Option[BigDecimal] = Some(scala.math.BigDecimal("9999.99")))

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -40,6 +40,9 @@ class StandardFileToFileSpec extends Specification {
     correctly generate all union values with shapeless Coproduct when instructed by generator $e19
     correctly generate union default parameter values $e20
     correctly generate a protocol with no ADT when asked $e21
+    correctly generate decimal from schema $e24
+    correctly generate decimal from protocol $e25
+    correctly generate decimal from IDL $e26
   """
   
   // tests standard to fileToX
@@ -354,6 +357,39 @@ class StandardFileToFileSpec extends Specification {
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(inOrderSchema, outDir)
     gen.fileToFile(inReportSchema, outDir) must throwA[Exception]
+  }
+
+  def e24 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/decimal.avsc")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/DecimalSc.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/DecimalSc.scala")
+  }
+
+  def e25 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/decimal.avpr")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/proto/DecimalPr.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/proto/DecimalPr.scala")
+  }
+
+  def e26 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/decimal.avdl")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/idl/DecimalIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/DecimalIdl.scala")
   }
 
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToStringsSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToStringsSpec.scala
@@ -32,11 +32,10 @@ class StandardFileToStringsSpec extends Specification {
       correctly generate records depending on others defined in a different- and same-namespaced AVDL and AVSC $e14
       correctly generate an empty case class definition $e15
       correctly generate default values $e16
-      
-      
-      
-      
+
+
       correctly generate a protocol with no ADT when asked $e21
+      correctly generate decimal from IDL $e22
   """
   
   // tests specific to fileToX
@@ -209,11 +208,6 @@ class StandardFileToStringsSpec extends Specification {
     source === expected
   }
   
-  
-  
-  
-  
-  
   def e21 = {
     val infile = new java.io.File("avrohugger-core/src/test/avro/AvroTypeProviderTestProtocol.avdl")
     val gen = new Generator(format = Standard)
@@ -221,6 +215,14 @@ class StandardFileToStringsSpec extends Specification {
     val List(source) = gen.fileToStrings(infile)
   
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard/test/Joystick.scala")
+  }
+
+  def e22 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/decimal.avdl")
+    val gen = new Generator(Standard)
+    val List(source) = gen.fileToStrings(infile)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/DecimalIdl.scala")
+    source === expected
   }
 
 }

--- a/avrohugger-core/src/test/scala/standard/StandardStringToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardStringToFileSpec.scala
@@ -33,6 +33,7 @@ class StandardStringToFileSpec extends Specification {
       
       
       correctly generate a protocol with no ADT when asked $e21
+      correctly generate decimal from IDL $e22
   """
   
   def eB = {
@@ -229,11 +230,7 @@ class StandardStringToFileSpec extends Specification {
     
     adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/Defaults.scala")
   }
-  
-  
-  
-  
-  
+
   def e21 = {
     val inputString = util.Util.readFile("avrohugger-core/src/test/avro/AvroTypeProviderTestProtocol.avdl")
     val gen = new Generator(format = Standard)
@@ -243,6 +240,17 @@ class StandardStringToFileSpec extends Specification {
     val source = util.Util.readFile("target/generated-sources/standard/test/Joystick.scala")
   
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard/test/Joystick.scala")
+  }
+
+  def e22 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/decimal.avdl")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.stringToFile(inputString, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/idl/DecimalIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/DecimalIdl.scala")
   }
 
 }

--- a/avrohugger-core/src/test/scala/standard/StandardStringToStringsSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardStringToStringsSpec.scala
@@ -36,6 +36,7 @@ class StandardStringToStringsSpec extends Specification {
       
       
       correctly generate a protocol with no ADT when asked $e21
+      correctly generate decimal values $e22
   """
   
   def eB = {
@@ -189,9 +190,6 @@ class StandardStringToStringsSpec extends Specification {
     source === expected
   }
 
-
-
-
   def e21 = {
     val inputString = util.Util.readFile("avrohugger-core/src/test/avro/AvroTypeProviderTestProtocol.avdl")
     val gen = new Generator(format = Standard)
@@ -199,5 +197,13 @@ class StandardStringToStringsSpec extends Specification {
     val List(source) = gen.stringToStrings(inputString)
   
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard/test/Joystick.scala")
+  }
+
+  def e22 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/decimal.avdl")
+    val gen = new Generator(Standard)
+    val List(source) = gen.stringToStrings(inputString)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/DecimalIdl.scala")
+    source === expected
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val avroVersion = "1.8.2"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "1.0.0-RC7",
+  version := "1.0.0-RC9-SNAPSHOT",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
   scalacOptions in Test ++= Seq("-Yrangepos"),
   scalaVersion := "2.12.6",


### PR DESCRIPTION
WIP

The following PR brings support for the `decimal` logical type available since avro 1.8.x
An idl file like this one:
```
@namespace("example.idl")

protocol DecimalIDL {

  record DecimalIdl {
    decimal(9, 2) dec = 8888.88;
    union {decimal(9, 2), null} maybeDec = 9999.99;
  }

}
```
generates:
```scala
/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
package example.idl

case class DecimalIdl(dec: BigDecimal = scala.math.BigDecimal("8888.88"), maybeDec: Option[BigDecimal] = Some(scala.math.BigDecimal("9999.99")))
```