### PR TITLE
Fixing missing shapeless import

### DIFF
--- a/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
+++ b/avrohugger-core/src/main/scala/format/standard/StandardImporter.scala
@@ -36,11 +36,11 @@ object StandardImporter extends Importer {
       case Schema.Type.MAP    => determineShapelessImports(field, schema.getValueType(), typeMatcher)
       case Schema.Type.RECORD => schema.getFields.asScala.toList.flatMap(f =>
                                    determineShapelessImports(field, f.schema(), typeMatcher))
-      case Schema.Type.BYTES  => importsForBigDecimalTaggedB(schema)
+      case Schema.Type.BYTES  => importsForBigDecimalTagged(schema)
       case _ => List.empty[String]
     }
 
-    def importsForBigDecimalTaggedB(schemas: Schema*): List[String] =
+    def importsForBigDecimalTagged(schemas: Schema*): List[String] =
       schemas.find { schema =>
         schema.getType == Schema.Type.BYTES && LogicalType.foldLogicalTypes(
           schema = schema,
@@ -75,7 +75,7 @@ object StandardImporter extends Importer {
       else
         List.empty[String]
 
-      unionImports ++ importsForBigDecimalTaggedB(unionTypes:_*)
+      unionImports ++ importsForBigDecimalTagged(unionTypes:_*)
     }
     val shapelessImport: List[String] => List[Import] = {
       case Nil          => Nil

--- a/avrohugger-core/src/test/avro/logical_coproduct.avdl
+++ b/avrohugger-core/src/test/avro/logical_coproduct.avdl
@@ -1,0 +1,9 @@
+@namespace("example.idl")
+
+protocol LogicalCoproductIDL {
+
+  record LogicalCoproductIdl {
+    union {decimal(9, 2), string, boolean} maybeDec = 9999.99;
+  }
+
+}

--- a/avrohugger-core/src/test/avro/logical_either.avdl
+++ b/avrohugger-core/src/test/avro/logical_either.avdl
@@ -1,0 +1,9 @@
+@namespace("example.idl")
+
+protocol LogicalEitherIDL {
+
+  record LogicalEitherIdl {
+    union {decimal(9, 2), string} maybeDec = 9999.99;
+  }
+
+}

--- a/avrohugger-core/src/test/avro/logical_optional.avdl
+++ b/avrohugger-core/src/test/avro/logical_optional.avdl
@@ -1,0 +1,9 @@
+@namespace("example.idl")
+
+protocol LogicalOptionalIDL {
+
+  record LogicalOptionalIdl {
+    union {decimal(9, 2), null} maybeDec = 9999.99;
+  }
+
+}

--- a/avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala
@@ -1,0 +1,6 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import shapeless.{:+:, CNil, Coproduct, tag.@@}
+
+case class LogicalCoproductIdl(maybeDec: scala.math.BigDecimal @@ (shapeless.Nat._9, shapeless.Nat._2) :+: String :+: Boolean :+: CNil = Coproduct[scala.math.BigDecimal @@ (shapeless.Nat._9, shapeless.Nat._2) :+: String :+: Boolean :+: CNil](shapeless.tag[(shapeless.Nat._9, shapeless.Nat._2)][scala.math.BigDecimal](scala.math.BigDecimal("9999.99"))))

--- a/avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalEitherIdl.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalEitherIdl.scala
@@ -1,0 +1,6 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import shapeless.tag.@@
+
+case class LogicalEitherIdl(maybeDec: Either[scala.math.BigDecimal @@ (shapeless.Nat._9, shapeless.Nat._2), String] = Left(shapeless.tag[(shapeless.Nat._9, shapeless.Nat._2)][scala.math.BigDecimal](scala.math.BigDecimal("9999.99"))))

--- a/avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalOptionalIdl.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalOptionalIdl.scala
@@ -1,0 +1,6 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import shapeless.tag.@@
+
+case class LogicalOptionalIdl(maybeDec: Option[scala.math.BigDecimal @@ (shapeless.Nat._9, shapeless.Nat._2)] = Some(shapeless.tag[(shapeless.Nat._9, shapeless.Nat._2)][scala.math.BigDecimal](scala.math.BigDecimal("9999.99"))))

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -55,6 +55,9 @@ class StandardFileToFileSpec extends Specification {
     correctly generate logical types from protocol tagged decimals $e33
     correctly generate logical types from IDL tagged decimals $e34
     correctly generate logical types with custom date and timestamp types tagged decimals $e35
+    correctly generate optional logical types from IDL tagged decimals $e36
+    correctly generate an either containing logical types from IDL tagged decimals $e37
+    correctly generate a coproduct containing logical types from IDL tagged decimals $e38
   """
   
   // tests standard to fileToX
@@ -513,4 +516,39 @@ class StandardFileToFileSpec extends Specification {
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSql.scala")
   }
 
+  def e36 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/logical_optional.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val outDir = gen.defaultOutputDir + "/standard-tagged/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalOptionalIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalOptionalIdl.scala")
+  }
+
+  def e37 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/logical_either.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val outDir = gen.defaultOutputDir + "/standard-tagged/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalEitherIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalEitherIdl.scala")
+  }
+
+  def e38 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/logical_coproduct.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val outDir = gen.defaultOutputDir + "/standard-tagged/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalCoproductIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala")
+  }
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToStringsSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToStringsSpec.scala
@@ -37,7 +37,10 @@ class StandardFileToStringsSpec extends Specification {
       correctly generate a protocol with no ADT when asked $e21
       correctly generate logical types from IDL $e22
       correctly generate logical types from IDL with tagged decimals $e23
-  """
+      correctly generate optional logical types from IDL tagged decimals $e24
+      correctly generate an either containing logical types from IDL tagged decimals $e25
+      correctly generate a coproduct containing logical types from IDL tagged decimals $e26
+    """
   
   // tests specific to fileToX
   def eA = {
@@ -235,4 +238,30 @@ class StandardFileToStringsSpec extends Specification {
     source === expected
   }
 
+  def e24 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/logical_optional.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val List(source) = gen.fileToStrings(infile)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalOptionalIdl.scala")
+    source === expected
+  }
+
+  def e25 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/logical_either.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val List(source) = gen.fileToStrings(infile)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalEitherIdl.scala")
+    source === expected
+  }
+
+  def e26 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/logical_coproduct.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val List(source) = gen.fileToStrings(infile)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala")
+    source === expected
+  }
 }

--- a/avrohugger-core/src/test/scala/standard/StandardStringToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardStringToFileSpec.scala
@@ -35,6 +35,9 @@ class StandardStringToFileSpec extends Specification {
       correctly generate a protocol with no ADT when asked $e21
       correctly generate logical types from IDL $e22
       correctly generate logical types from IDL with tagged decimals $e23
+      correctly generate optional logical types from IDL tagged decimals $e24
+      correctly generate an either containing logical types from IDL tagged decimals $e25
+      correctly generate a coproduct containing logical types from IDL tagged decimals $e26
   """
   
   def eB = {
@@ -266,4 +269,39 @@ class StandardStringToFileSpec extends Specification {
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalIdl.scala")
   }
 
+  def e24 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/logical_optional.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val outDir = gen.defaultOutputDir + "/standard-tagged/"
+    gen.stringToFile(inputString, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalOptionalIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalOptionalIdl.scala")
+  }
+
+  def e25 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/logical_either.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val outDir = gen.defaultOutputDir + "/standard-tagged/"
+    gen.stringToFile(inputString, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalEitherIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalEitherIdl.scala")
+  }
+
+  def e26 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/logical_coproduct.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val outDir = gen.defaultOutputDir + "/standard-tagged/"
+    gen.stringToFile(inputString, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalCoproductIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala")
+  }
 }

--- a/avrohugger-core/src/test/scala/standard/StandardStringToStringsSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardStringToStringsSpec.scala
@@ -38,6 +38,9 @@ class StandardStringToStringsSpec extends Specification {
       correctly generate a protocol with no ADT when asked $e21
       correctly generate logical types values $e22
       correctly generate logical types values with tagged decimals $e23
+      correctly generate optional logical types from IDL tagged decimals $e24
+      correctly generate an either containing logical types from IDL tagged decimals $e25
+      correctly generate a coproduct containing logical types from IDL tagged decimals $e26
   """
   
   def eB = {
@@ -214,6 +217,33 @@ class StandardStringToStringsSpec extends Specification {
     val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
     val List(source) = gen.stringToStrings(inputString)
     val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalIdl.scala")
+    source === expected
+  }
+
+  def e24 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/logical_optional.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val List(source) = gen.stringToStrings(inputString)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalOptionalIdl.scala")
+    source === expected
+  }
+
+  def e25 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/logical_either.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val List(source) = gen.stringToStrings(inputString)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalEitherIdl.scala")
+    source === expected
+  }
+
+  def e26 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/logical_coproduct.avdl")
+    val myAvroScalaCustomTypes = Standard.defaultTypes.copy(decimal = ScalaBigDecimalWithPrecision)
+    val gen = new Generator(Standard, avroScalaCustomTypes = Some(myAvroScalaCustomTypes))
+    val List(source) = gen.stringToStrings(inputString)
+    val expected = util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala")
     source === expected
   }
 }


### PR DESCRIPTION
This pull request fixes an issue that happens when using a `decimal` logical type within a `union` type.

So an IDL file like this one:
```
@namespace("example.idl")

protocol LogicalOptionalIDL {
  record LogicalOptionalIdl {
    union {decimal(9, 2), null} maybeDec = 9999.99;
  }
}
```
causes a compilation error because the `shapeless.tag.@@` import is missing.

The root cause is the `importsForUnionType` method doesn't check if the contained types require more imports so that leads to a compilation error.