### PR TITLE
Fix specific generator for UNIONs with decimal inside

### DIFF
--- a/avrohugger-core/src/test/avro/nullable_bigdecimal.avsc
+++ b/avrohugger-core/src/test/avro/nullable_bigdecimal.avsc
@@ -1,0 +1,20 @@
+{
+  "type": "record",
+  "name": "NullableDecimal",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "ciao",
+      "type": [
+        "null",
+        {
+          "type": "bytes",
+          "scale": 5,
+          "precision": 64,
+          "logicalType": "decimal"
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/specific/com/example/NullableDecimal.scala
+++ b/avrohugger-core/src/test/expected/specific/com/example/NullableDecimal.scala
@@ -1,0 +1,50 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example
+
+import scala.annotation.switch
+
+case class NullableDecimal(var ciao: Option[BigDecimal] = None) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(None)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        ciao match {
+          case Some(x) => {
+            val schema = getSchema.getFields().get(field$).schema()
+            val decimalType = schema.getLogicalType().asInstanceOf[org.apache.avro.LogicalTypes.Decimal]
+            val scale = decimalType.getScale()
+            val scaledValue = x.setScale(scale)
+            val bigDecimal = scaledValue.bigDecimal
+            NullableDecimal.decimalConversion.toBytes(bigDecimal, schema, decimalType)
+          }
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.ciao = {
+        value match {
+          case null => None
+          case _ => Some(value match {
+            case (buffer: java.nio.ByteBuffer) => {
+              val schema = getSchema.getFields().get(field$).schema()
+              val decimalType = schema.getLogicalType().asInstanceOf[org.apache.avro.LogicalTypes.Decimal]
+              BigDecimal(NullableDecimal.decimalConversion.fromBytes(buffer, schema, decimalType))
+            }
+          })
+        }
+      }.asInstanceOf[Option[BigDecimal]]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = NullableDecimal.SCHEMA$
+}
+
+object NullableDecimal {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"NullableDecimal\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"ciao\",\"type\":[\"null\",{\"type\":\"bytes\",\"scale\":5,\"precision\":64,\"logicalType\":\"decimal\"}],\"default\":null}]}")
+  val decimalConversion = new org.apache.avro.Conversions.DecimalConversion
+}

--- a/avrohugger-core/src/test/scala/specific/SpecificNullableBigDecimalSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificNullableBigDecimalSpec.scala
@@ -1,0 +1,23 @@
+package avrohugger
+package test
+package specific
+
+import org.specs2._
+import avrohugger._
+import avrohugger.format.SpecificRecord
+import avrohugger.types._
+
+class SpecificNullableBigDecimalSpec extends Specification {
+  def is = s2"SpecificFileGenerator should correctly support nullable decimals $e1"
+
+  def e1 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/nullable_bigdecimal.avsc")
+    val gen = new Generator(SpecificRecord)
+    val outDir = gen.defaultOutputDir + "/specific/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/specific/com/example/NullableDecimal.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/specific/com/example/NullableDecimal.scala")
+  }
+}


### PR DESCRIPTION
When generator decides if there are decimal fields in the schema, it traverses all top level fields, but does not jump into UNION type. So if there is decimal inside, it's ignored.

Fixes #107

Maybe there is more generic way to approach this problem when there are deeply nested UNIONs, but I could't come up with recursive traversal at first glance.