### PR TITLE
Optionally limit the depth of nested schemas to reduce number of superfluous imports

### DIFF
--- a/avrohugger-core/src/main/scala/format/abstractions/Importer.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/Importer.scala
@@ -170,9 +170,9 @@ trait Importer {
     typeMatcher: TypeMatcher): List[Schema] = {
     schemaOrProtocol match {
       case Left(schema) =>
-        schema::(NestedSchemaExtractor.getNestedSchemas(schema, schemaStore, typeMatcher))
+        schema::(NestedSchemaExtractor.getNestedSchemas(schema, schemaStore, typeMatcher, Some(1)))
       case Right(protocol) => protocol.getTypes.asScala.toList.flatMap(schema => {
-        schema::(NestedSchemaExtractor.getNestedSchemas(schema, schemaStore, typeMatcher))
+        schema::(NestedSchemaExtractor.getNestedSchemas(schema, schemaStore, typeMatcher, Some(1)))
       })
     }
 

--- a/avrohugger-core/src/main/scala/input/NestedSchemaExtractor.scala
+++ b/avrohugger-core/src/main/scala/input/NestedSchemaExtractor.scala
@@ -15,48 +15,53 @@ object NestedSchemaExtractor {
   def getNestedSchemas(
     schema: Schema,
     schemaStore: SchemaStore,
-    typeMatcher: TypeMatcher): List[Schema] = {
+    typeMatcher: TypeMatcher,
+    maxDepth: Option[Int] = None): List[Schema] = {
     def extract(
       schema: Schema,
-      fieldPath: List[String] = List.empty): List[Schema] = {
-
-      schema.getType match {
-        case RECORD =>
-          val fields: List[Schema.Field] = schema.getFields.asScala.toList
-          val fieldSchemas: List[Schema] = fields.map(field => field.schema)
-          def flattenSchema(fieldSchema: Schema): List[Schema] = {
-            fieldSchema.getType match {
-              case ARRAY => flattenSchema(fieldSchema.getElementType)
-              case MAP => flattenSchema(fieldSchema.getValueType)
-              case RECORD => {
-                // if the field schema is one that has already been stored, use that one
-                if (schemaStore.schemas.contains(fieldSchema.getFullName)) List()
-                // if we've already seen this schema (recursive schemas) don't traverse further
-                else if (fieldPath.contains(fieldSchema.getFullName)) List()
-                else fieldSchema :: extract(fieldSchema, fieldSchema.getFullName :: fieldPath)
+      fieldPath: List[String],
+      currentMaxDepth: Option[Int]): List[Schema] = {
+      
+      if (currentMaxDepth.exists(_ <= 0))
+        List.empty
+      else
+        schema.getType match {
+          case RECORD =>
+            val fields: List[Schema.Field] = schema.getFields.asScala.toList
+            val fieldSchemas: List[Schema] = fields.map(field => field.schema)
+            def flattenSchema(fieldSchema: Schema): List[Schema] = {
+              fieldSchema.getType match {
+                case ARRAY => flattenSchema(fieldSchema.getElementType)
+                case MAP   => flattenSchema(fieldSchema.getValueType)
+                case RECORD => {
+                  // if the field schema is one that has already been stored, use that one
+                  if (schemaStore.schemas.contains(fieldSchema.getFullName)) List()
+                  // if we've already seen this schema (recursive schemas) don't traverse further
+                  else if (fieldPath.contains(fieldSchema.getFullName)) List()
+                  else fieldSchema :: extract(fieldSchema, fieldSchema.getFullName :: fieldPath, currentMaxDepth.map(_ - 1))
+                }
+                case UNION => fieldSchema.getTypes.asScala.toList.flatMap(x => flattenSchema(x))
+                case ENUM => {
+                  // if the field schema is one that has already been stored, use that one
+                  if (schemaStore.schemas.contains(fieldSchema.getFullName)) List()
+                  else List(fieldSchema)
+                }
+                case _ => List(fieldSchema)
               }
-              case UNION => fieldSchema.getTypes.asScala.toList.flatMap(x => flattenSchema(x))
-              case ENUM => {
-                // if the field schema is one that has already been stored, use that one
-                if (schemaStore.schemas.contains(fieldSchema.getFullName)) List()
-                else List(fieldSchema)
-              }
-              case _ => List(fieldSchema)
             }
-          }
-          val flatSchemas = fieldSchemas.flatMap(fieldSchema => flattenSchema(fieldSchema))
-          def topLevelTypes(schema: Schema) = {
-            if (typeMatcher.avroScalaTypes.enum == EnumAsScalaString) schema.getType == RECORD
-            else (schema.getType == RECORD | schema.getType == ENUM)
-          }
-          val nestedTopLevelSchemas = flatSchemas.filter(topLevelTypes)
-          nestedTopLevelSchemas
-        case ENUM => List(schema)
-        case _ => Nil
-      } 
+            val flatSchemas = fieldSchemas.flatMap(fieldSchema => flattenSchema(fieldSchema))
+            def topLevelTypes(schema: Schema) = {
+              if (typeMatcher.avroScalaTypes.enum == EnumAsScalaString) schema.getType == RECORD
+              else (schema.getType == RECORD | schema.getType == ENUM)
+            }
+            val nestedTopLevelSchemas = flatSchemas.filter(topLevelTypes)
+            nestedTopLevelSchemas
+          case ENUM => List(schema)
+          case _ => Nil
+        } 
     }
 
-    schema::extract(schema)
+    schema :: extract(schema, List.empty, maxDepth)
   }
 }
 

--- a/avrohugger-core/src/test/avro/import_nested1.avsc
+++ b/avrohugger-core/src/test/avro/import_nested1.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "example.importing.nested.foo",
+  "type": "enum",
+  "name": "Status",
+  "symbols": [
+    "Created",
+    "InProgress",
+    "Finished"
+  ]
+}

--- a/avrohugger-core/src/test/avro/import_nested2.avsc
+++ b/avrohugger-core/src/test/avro/import_nested2.avsc
@@ -1,0 +1,24 @@
+{
+  "namespace": "example.importing.nested.bar",
+  "type": "record",
+  "name": "BarOuter",
+  "fields": [
+    {
+      "name": "inner",
+      "type": {
+        "name": "BarInner",
+        "type": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "type": "example.importing.nested.foo.Status"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/scavro/example/importing/nested/bar/model/BarOuter.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/importing/nested/bar/model/BarOuter.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.importing.nested.bar.model
+
+import org.apache.avro.Schema
+
+import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
+
+import example.importing.nested.bar.{BarInner => JBarInner, BarOuter => JBarOuter}
+
+import example.importing.nested.foo.{Status => JStatus}
+
+case class BarOuter(inner: BarInner) extends AvroSerializeable {
+  type J = JBarOuter
+  override def toAvro: JBarOuter = {
+    new JBarOuter(inner.toAvro)
+  }
+}
+
+object BarOuter {
+  implicit def reader = new AvroReader[BarOuter] {
+    override type J = JBarOuter
+  }
+  implicit val metadata: AvroMetadata[BarOuter, JBarOuter] = new AvroMetadata[BarOuter, JBarOuter] {
+    override val avroClass: Class[JBarOuter] = classOf[JBarOuter]
+    override val schema: Schema = JBarOuter.getClassSchema()
+    override val fromAvro: (JBarOuter) => BarOuter = {
+      (j: JBarOuter) => BarOuter(BarInner.metadata.fromAvro(j.getInner))
+    }
+  }
+}

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
@@ -5,7 +5,7 @@ import org.apache.avro.Schema
 
 import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
-import example.avro.{ClashInner => JClashInner, ClashOuter => JClashOuter, ClashRecord => JClashRecord}
+import example.avro.{ClashOuter => JClashOuter, ClashRecord => JClashRecord}
 
 import scala.collection.JavaConverters._
 

--- a/avrohugger-core/src/test/expected/specific/example/importing/nested/bar/BarOuter.scala
+++ b/avrohugger-core/src/test/expected/specific/example/importing/nested/bar/BarOuter.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.importing.nested.bar
+
+import scala.annotation.switch
+
+case class BarOuter(var inner: BarInner) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(new BarInner)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        inner
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.inner = {
+        value
+      }.asInstanceOf[BarInner]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = BarOuter.SCHEMA$
+}
+
+object BarOuter {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"BarOuter\",\"namespace\":\"example.importing.nested.bar\",\"fields\":[{\"name\":\"inner\",\"type\":{\"type\":\"record\",\"name\":\"BarInner\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"status\",\"type\":{\"type\":\"enum\",\"name\":\"Status\",\"namespace\":\"example.importing.nested.foo\",\"symbols\":[\"Created\",\"InProgress\",\"Finished\"]}}]}}]}")
+}

--- a/avrohugger-core/src/test/expected/standard/example/importing/nested/bar/BarOuter.scala
+++ b/avrohugger-core/src/test/expected/standard/example/importing/nested/bar/BarOuter.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.importing.nested.bar
+
+case class BarOuter(inner: BarInner)

--- a/avrohugger-core/src/test/scala/scavro/ScavroNestedSpec.scala
+++ b/avrohugger-core/src/test/scala/scavro/ScavroNestedSpec.scala
@@ -1,0 +1,32 @@
+package scavro
+
+import avrohugger._
+import avrohugger.format.Scavro
+import org.specs2._
+
+class ScavroNestedSpec extends Specification {
+
+  def is = s2"""
+    A Scavro Generator should
+      generate import only when needed $e1
+  """
+
+  def e1 = {
+    val infile1 =
+      new java.io.File("avrohugger-core/src/test/avro/import_nested1.avsc")
+    val infile2 =
+      new java.io.File("avrohugger-core/src/test/avro/import_nested2.avsc")
+    val gen = new Generator(format = Scavro)
+    val outDir = gen.defaultOutputDir + "/scavro"
+    gen.fileToFile(infile1, outDir)
+    gen.fileToFile(infile2, outDir)
+
+    val generated =
+      util.Util.readFile(s"$outDir/example/importing/nested/bar/model/BarOuter.scala")
+    val expected = 
+      util.Util.readFile("avrohugger-core/src/test/expected/scavro/example/importing/nested/bar/model/BarOuter.scala")
+    generated ==== expected
+
+  }
+
+}

--- a/avrohugger-core/src/test/scala/specific/SpecificNestedSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificNestedSpec.scala
@@ -1,0 +1,30 @@
+package specific
+
+import avrohugger._
+import avrohugger.format.SpecificRecord
+import org.specs2._
+
+class SpecificNestedSpec extends Specification {
+
+  def is = s2"""
+    A Specific Generator should
+      generate import only when needed $e1
+  """
+
+  def e1 = {
+    val infile1 =
+      new java.io.File("avrohugger-core/src/test/avro/import_nested1.avsc")
+    val infile2 =
+      new java.io.File("avrohugger-core/src/test/avro/import_nested2.avsc")
+    val gen = new Generator(format = SpecificRecord)
+    val outDir = gen.defaultOutputDir + "/specific"
+    gen.fileToFile(infile1, outDir)
+    gen.fileToFile(infile2, outDir)
+
+    val generated =
+      util.Util.readFile(s"$outDir/example/importing/nested/bar/BarOuter.scala")
+    val expected = 
+      util.Util.readFile("avrohugger-core/src/test/expected/specific/example/importing/nested/bar/BarOuter.scala")
+    generated ==== expected
+  }
+}

--- a/avrohugger-core/src/test/scala/standard/StandardNestedSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardNestedSpec.scala
@@ -1,0 +1,32 @@
+package standard
+
+import avrohugger._
+import avrohugger.format.Standard
+import org.specs2._
+
+class StandardNestedSpec extends Specification {
+
+  def is = s2"""
+    A Standard Generator should
+      generate import only when needed $e1
+  """
+
+  def e1 = {
+    val infile1 =
+      new java.io.File("avrohugger-core/src/test/avro/import_nested1.avsc")
+    val infile2 =
+      new java.io.File("avrohugger-core/src/test/avro/import_nested2.avsc")
+    val gen = new Generator(format = Standard)
+    val outDir = gen.defaultOutputDir + "/standard"
+    gen.fileToFile(infile1, outDir)
+    gen.fileToFile(infile2, outDir)
+
+    val generated =
+      util.Util.readFile(s"$outDir/example/importing/nested/bar/BarOuter.scala")
+    val expected = 
+      util.Util.readFile("avrohugger-core/src/test/expected/standard/example/importing/nested/bar/BarOuter.scala")
+    generated ==== expected
+
+  }
+
+}


### PR DESCRIPTION
We have nested records that produce two classes, `Outer` and `Inner`. If the `Inner` class uses a class from a different package, it would import it. However, the `Outer` class would import it as well with the current version of avrohugger.

This produces warnings in scala compiler if flag `-Ywarn-unused-import:true` is used.

This PR fixes it by providing an option to limit the depths that the `Importer` would go searching for imports of dependent schemas. 

The new tests add a case for this scenario. Without this PR, those that would fail because the `BarOuter` class would have `import example.importing.nested.foo.Status`.