### PR TITLE
Add support for keywords as field names and other exceptional spelling.

### DIFF
--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -1,0 +1,17 @@
+package avrohugger
+package format
+
+object FieldRenamer {
+  val RESERVED_WORDS: Set[String] = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch",
+    "char", "class", "const", "continue", "default", "do", "double",
+    "else", "enum", "extends", "false", "final", "finally", "float",
+    "for", "goto", "if", "implements", "import", "instanceof", "int",
+    "interface", "long", "native", "new", "null", "package", "private",
+    "protected", "public", "return", "short", "static", "strictfp",
+    "super", "switch", "synchronized", "this", "throw", "throws",
+    "transient", "true", "try", "void", "volatile", "while")
+
+  def backtick(variable: String): String = s"`$variable`"
+
+  def rename(fieldName: String): String = if(RESERVED_WORDS.contains(fieldName)) backtick(fieldName) else if (fieldName.endsWith("_")) backtick(fieldName) else fieldName
+}

--- a/avrohugger-core/src/main/scala/format/scavro/trees/ScavroCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/trees/ScavroCaseClassTree.scala
@@ -36,7 +36,7 @@ object ScavroCaseClassTree {
     val shouldGenerateSimpleClass = restrictedFields && avroFields.size > 22
 
     val scalaClassParams: List[ValDef] = avroFields.map { f =>
-      val fieldName = f.name
+      val fieldName = FieldRenamer.rename(f.name)
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
       val defaultValue = DefaultValueMatcher.getDefaultValue(
         classStore,

--- a/avrohugger-core/src/main/scala/format/specific/trees/SpecificCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/specific/trees/SpecificCaseClassTree.scala
@@ -32,7 +32,7 @@ object SpecificCaseClassTree {
 
     // generate list of constructor parameters
     val params: List[ValDef] = avroFields.map { f =>
-      val fieldName = f.name
+      val fieldName = FieldRenamer.rename(f.name)
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
       val defaultValue = DefaultValueMatcher.getDefaultValue(
         classStore,

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -18,19 +18,6 @@ import scala.collection.JavaConverters._
 
 object StandardCaseClassTree {
 
-  val RESERVED_WORDS: Set[String] = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch",
-    "char", "class", "const", "continue", "default", "do", "double",
-    "else", "enum", "extends", "false", "final", "finally", "float",
-    "for", "goto", "if", "implements", "import", "instanceof", "int",
-    "interface", "long", "native", "new", "null", "package", "private",
-    "protected", "public", "return", "short", "static", "strictfp",
-    "super", "switch", "synchronized", "this", "throw", "throws",
-    "transient", "true", "try", "void", "volatile", "while")
-
-  def backtick(variable: String): String = s"`$variable`"
-
-  def fieldRenamer(fieldName: String): String = if(RESERVED_WORDS.contains(fieldName)) backtick(fieldName) else if (fieldName.endsWith("_")) backtick(fieldName) else fieldName
-
   def toCaseClassDef(
     classStore: ClassStore,
     namespace: Option[String],
@@ -47,7 +34,7 @@ object StandardCaseClassTree {
     val shouldGenerateSimpleClass = restrictedFields && avroFields.size > 22
 
     val params: List[ValDef] = avroFields.map(f => {
-      val fieldName = fieldRenamer(f.name)
+      val fieldName = FieldRenamer.rename(f.name)
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
       val defaultValue = DefaultValueMatcher.getDefaultValue(
         classStore,

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -18,6 +18,19 @@ import scala.collection.JavaConverters._
 
 object StandardCaseClassTree {
 
+  val RESERVED_WORDS: Set[String] = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch",
+    "char", "class", "const", "continue", "default", "do", "double",
+    "else", "enum", "extends", "false", "final", "finally", "float",
+    "for", "goto", "if", "implements", "import", "instanceof", "int",
+    "interface", "long", "native", "new", "null", "package", "private",
+    "protected", "public", "return", "short", "static", "strictfp",
+    "super", "switch", "synchronized", "this", "throw", "throws",
+    "transient", "true", "try", "void", "volatile", "while")
+
+  def backtick(variable: String): String = s"`$variable`"
+
+  def fieldRenamer(fieldName: String): String = if(RESERVED_WORDS.contains(fieldName)) backtick(fieldName) else if (fieldName.endsWith("_")) backtick(fieldName) else fieldName
+
   def toCaseClassDef(
     classStore: ClassStore,
     namespace: Option[String],
@@ -34,7 +47,7 @@ object StandardCaseClassTree {
     val shouldGenerateSimpleClass = restrictedFields && avroFields.size > 22
 
     val params: List[ValDef] = avroFields.map(f => {
-      val fieldName = f.name
+      val fieldName = fieldRenamer(f.name)
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
       val defaultValue = DefaultValueMatcher.getDefaultValue(
         classStore,

--- a/avrohugger-core/src/test/avro/special_names.avdl
+++ b/avrohugger-core/src/test/avro/special_names.avdl
@@ -1,0 +1,8 @@
+@namespace("example.idl")
+protocol SpecialNames {
+
+  record Names {
+    string `public`;
+    string `ends_with_`;
+  }
+}

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
@@ -1,0 +1,28 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl.model
+
+import org.apache.avro.Schema
+
+import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
+
+import example.idl.{Names => JNames}
+
+case class Names(`public`: String, `ends_with_`: String) extends AvroSerializeable {
+  type J = JNames
+  override def toAvro: JNames = {
+    new JNames(public, ends_with_)
+  }
+}
+
+object Names {
+  implicit def reader = new AvroReader[Names] {
+    override type J = JNames
+  }
+  implicit val metadata: AvroMetadata[Names, JNames] = new AvroMetadata[Names, JNames] {
+    override val avroClass: Class[JNames] = classOf[JNames]
+    override val schema: Schema = JNames.getClassSchema()
+    override val fromAvro: (JNames) => Names = {
+      (j: JNames) => Names(j.getPublic$.toString, j.getEndsWith.toString)
+    }
+  }
+}

--- a/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
@@ -1,0 +1,36 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+import scala.annotation.switch
+
+case class Names(var `public`: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this("", "")
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        public
+      }.asInstanceOf[AnyRef]
+      case 1 => {
+        ends_with_
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.public = {
+        value.toString
+      }.asInstanceOf[String]
+      case 1 => this.ends_with_ = {
+        value.toString
+      }.asInstanceOf[String]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = Names.SCHEMA$
+}
+
+object Names {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Names\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"public\",\"type\":\"string\"},{\"name\":\"ends_with_\",\"type\":\"string\"}]}")
+}

--- a/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+case class Names(`public`: String, `ends_with_`: String)

--- a/avrohugger-core/src/test/scala/scavro/ScavroFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/scavro/ScavroFileToFileSpec.scala
@@ -38,6 +38,7 @@ class ScavroFileToFileSpec extends Specification {
     correctly generate a protocol with no ADT when asked $e21
     correctly generate cases classes for AVSC files that have a equivalent common element $e22
     correctly fail if AVSC files contain non-equivalent common element $e23
+    correctly generate a class with special names $e24
   """
 
   def eA = {
@@ -263,5 +264,16 @@ class ScavroFileToFileSpec extends Specification {
     val outDir = gen.defaultOutputDir + "/scavro/"
     gen.fileToFile(inOrderSchema, outDir)
     gen.fileToFile(inReportSchema, outDir) must throwA[Exception]
+  }
+
+  def e24 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/special_names.avdl")
+    val gen = new Generator(Scavro)
+    val outDir = gen.defaultOutputDir + "/scavro/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/scavro/example/idl/model/Names.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala")
   }
 }

--- a/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
@@ -45,6 +45,7 @@ class SpecificFileToFileSpec extends Specification {
       correctly generate logical types from protocol $e25
       correctly generate logical types from IDL $e26
       correctly generate logical types with custom date and timestamp types $e27
+      correctly generate a protocol with special strings $e28
   """
 
   // tests specific to fileToX
@@ -352,5 +353,16 @@ class SpecificFileToFileSpec extends Specification {
     val source = util.Util.readFile("target/generated-sources/specific/example/logical/LogicalSql.scala")
 
     source === util.Util.readFile("avrohugger-core/src/test/expected/specific/example/logical/LogicalSql.scala")
+  }
+
+  def e28 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/special_names.avdl")
+    val gen = new Generator(SpecificRecord)
+    val outDir = gen.defaultOutputDir + "/specific/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/specific/example/idl/Names.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/specific/example/idl/Names.scala")
   }
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -58,6 +58,7 @@ class StandardFileToFileSpec extends Specification {
     correctly generate optional logical types from IDL tagged decimals $e36
     correctly generate an either containing logical types from IDL tagged decimals $e37
     correctly generate a coproduct containing logical types from IDL tagged decimals $e38
+    correctly generate a protocol with special strings $e39
   """
   
   // tests standard to fileToX
@@ -550,5 +551,16 @@ class StandardFileToFileSpec extends Specification {
     val source = util.Util.readFile("target/generated-sources/standard-tagged/example/idl/LogicalCoproductIdl.scala")
 
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard-tagged/example/idl/LogicalCoproductIdl.scala")
+  }
+
+  def e39 = {
+    val infile = new java.io.File("avrohugger-core/src/test/avro/special_names.avdl")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/idl/Names.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/Names.scala")
   }
 }


### PR DESCRIPTION
This closes julianpeeters/sbt-avrohugger#70, by placing backticks around reserved words and words ending with `_` as a field name.

Thanks for the helpful advice on where to look @julianpeeters 