### PR TITLE
Mangles names of reserved words

### DIFF
--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -13,7 +13,7 @@ object FieldRenamer {
 
   def backtick(variable: String): String = s"`$variable`"
 
-  def mangle(variable: String): String = s"_$$$$${variable}"
+  def mangle(variable: String): String = s"_${variable}"
 
   def isMangled(fieldName: String): Boolean = RESERVED_WORDS.contains(fieldName)
 

--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -13,5 +13,9 @@ object FieldRenamer {
 
   def backtick(variable: String): String = s"`$variable`"
 
-  def rename(fieldName: String): String = if(RESERVED_WORDS.contains(fieldName)) backtick(fieldName) else if (fieldName.endsWith("_")) backtick(fieldName) else fieldName
+  def mangle(variable: String): String = s"_$$$$${variable}"
+
+  def isMangled(fieldName: String): Boolean = RESERVED_WORDS.contains(fieldName)
+
+  def rename(fieldName: String): String = if(isMangled(fieldName)) mangle(fieldName) else if (fieldName.endsWith("_")) backtick(fieldName) else fieldName
 }

--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -13,7 +13,7 @@ object FieldRenamer {
 
   def backtick(variable: String): String = s"`$variable`"
 
-  def mangle(variable: String): String = s"__${variable}"
+  def mangle(variable: String): String = variable + "$"
 
   def isMangled(fieldName: String): Boolean = RESERVED_WORDS.contains(fieldName)
 

--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -13,7 +13,7 @@ object FieldRenamer {
 
   def backtick(variable: String): String = s"`$variable`"
 
-  def mangle(variable: String): String = s"_${variable}"
+  def mangle(variable: String): String = s"__${variable}"
 
   def isMangled(fieldName: String): Boolean = RESERVED_WORDS.contains(fieldName)
 

--- a/avrohugger-core/src/main/scala/format/scavro/trees/ScavroCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/trees/ScavroCaseClassTree.scala
@@ -48,7 +48,7 @@ object ScavroCaseClassTree {
 
     val scalaClassAccessors: List[Tree] = avroFields.map(field => {
       val javaConverter = new JavaConverter(classStore, namespace, typeMatcher)
-      javaConverter.convertToJava(field.schema, REF(field.name))
+      javaConverter.convertToJava(field.schema, REF(FieldRenamer.rename(field.name)))
     })
 
     // There could be base traits, flags, or both, and could have no fields

--- a/avrohugger-core/src/main/scala/format/specific/methods/GetGenerator.scala
+++ b/avrohugger-core/src/main/scala/format/specific/methods/GetGenerator.scala
@@ -24,7 +24,7 @@ object GetGenerator {
           field.avroField.schema,
           REF("getSchema").DOT("getFields").APPLY().DOT("get").APPLY(REF("field$")).DOT("schema").APPLY(),
           false,
-          REF(field.avroField.name),
+          REF(FieldRenamer.rename(field.avroField.name)),
           classSymbol,
           typeMatcher)).AS(AnyRefClass)
       }

--- a/avrohugger-core/src/main/scala/format/specific/methods/PutGenerator.scala
+++ b/avrohugger-core/src/main/scala/format/specific/methods/PutGenerator.scala
@@ -22,7 +22,7 @@ object PutGenerator {
 
       def asPutCase(field: IndexedField) = {
         CASE (LIT(field.idx)) ==> {
-          THIS DOT field.avroField.name := 
+          THIS DOT FieldRenamer.rename(field.avroField.name) :=
             BLOCK(ScalaConverter.convertFromJava(
               classStore,
               namespace,

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -35,13 +35,18 @@ object StandardCaseClassTree {
 
     val params: List[ValDef] = avroFields.map(f => {
       val fieldName = FieldRenamer.rename(f.name)
+      val isMangled = FieldRenamer.isMangled(f.name())
       val fieldType = typeMatcher.toScalaType(classStore, namespace, f.schema)
       val defaultValue = DefaultValueMatcher.getDefaultValue(
         classStore,
         namespace,
         f,
         typeMatcher)
-      PARAM(fieldName, fieldType) := defaultValue
+      if(isMangled) {
+        VAL(fieldName, fieldType).withFlags(Flags.PRIVATE) := defaultValue
+      } else {
+        PARAM(fieldName, fieldType) := defaultValue
+      }
     })
 
     // There could be base traits, flags, or both, and could have no fields
@@ -118,7 +123,17 @@ object StandardCaseClassTree {
       }
     }
 
-    val classTree = caseClassDef.tree
+    val mangledClass = if(avroFields.count(f => FieldRenamer.isMangled(f.name())) > 0) {
+      caseClassDef := BLOCK(
+        avroFields.flatMap { field =>
+          if(FieldRenamer.isMangled(field.name()))
+            Some(VAL(FieldRenamer.backtick(field.name()), typeMatcher.toScalaType(classStore, namespace, field.schema)) := REF(FieldRenamer.mangle(field.name())))
+          else None
+        }
+      )
+    } else caseClassDef.tree
+
+    val classTree = mangledClass
 
 
     val treeWithScalaDoc = ScalaDocGenerator.docToScalaDoc(

--- a/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/standard/trees/StandardCaseClassTree.scala
@@ -123,7 +123,7 @@ object StandardCaseClassTree {
       }
     }
 
-    val mangledClass = if(avroFields.count(f => FieldRenamer.isMangled(f.name())) > 0) {
+    val classTree = if(avroFields.count(f => FieldRenamer.isMangled(f.name())) > 0) {
       caseClassDef := BLOCK(
         avroFields.flatMap { field =>
           if(FieldRenamer.isMangled(field.name()))
@@ -132,9 +132,6 @@ object StandardCaseClassTree {
         }
       )
     } else caseClassDef.tree
-
-    val classTree = mangledClass
-
 
     val treeWithScalaDoc = ScalaDocGenerator.docToScalaDoc(
       Left(schema),

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
@@ -7,10 +7,10 @@ import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
 import example.idl.{Names => JNames}
 
-case class Names(`public`: String, `ends_with_`: String) extends AvroSerializeable {
+case class Names(_$$public: String, `ends_with_`: String) extends AvroSerializeable {
   type J = JNames
   override def toAvro: JNames = {
-    new JNames(public, ends_with_)
+    new JNames(_$$public, `ends_with_`)
   }
 }
 

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
@@ -7,10 +7,10 @@ import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
 import example.idl.{Names => JNames}
 
-case class Names(__public: String, `ends_with_`: String) extends AvroSerializeable {
+case class Names(public$: String, `ends_with_`: String) extends AvroSerializeable {
   type J = JNames
   override def toAvro: JNames = {
-    new JNames(__public, `ends_with_`)
+    new JNames(public$, `ends_with_`)
   }
 }
 

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
@@ -7,10 +7,10 @@ import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
 import example.idl.{Names => JNames}
 
-case class Names(_$$public: String, `ends_with_`: String) extends AvroSerializeable {
+case class Names(__public: String, `ends_with_`: String) extends AvroSerializeable {
   type J = JNames
   override def toAvro: JNames = {
-    new JNames(_$$public, `ends_with_`)
+    new JNames(__public, `ends_with_`)
   }
 }
 

--- a/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
@@ -3,25 +3,25 @@ package example.idl
 
 import scala.annotation.switch
 
-case class Names(var `public`: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
+case class Names(var _$$public: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this("", "")
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
-        public
+        _$$public
       }.asInstanceOf[AnyRef]
       case 1 => {
-        ends_with_
+        `ends_with_`
       }.asInstanceOf[AnyRef]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
   def put(field$: Int, value: Any): Unit = {
     (field$: @switch) match {
-      case 0 => this.public = {
+      case 0 => this._$$public = {
         value.toString
       }.asInstanceOf[String]
-      case 1 => this.ends_with_ = {
+      case 1 => this.`ends_with_` = {
         value.toString
       }.asInstanceOf[String]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")

--- a/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
@@ -3,12 +3,12 @@ package example.idl
 
 import scala.annotation.switch
 
-case class Names(var __public: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
+case class Names(var public$: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this("", "")
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
-        __public
+        public$
       }.asInstanceOf[AnyRef]
       case 1 => {
         `ends_with_`
@@ -18,7 +18,7 @@ case class Names(var __public: String, var `ends_with_`: String) extends org.apa
   }
   def put(field$: Int, value: Any): Unit = {
     (field$: @switch) match {
-      case 0 => this.__public = {
+      case 0 => this.public$ = {
         value.toString
       }.asInstanceOf[String]
       case 1 => this.`ends_with_` = {

--- a/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
@@ -3,12 +3,12 @@ package example.idl
 
 import scala.annotation.switch
 
-case class Names(var _$$public: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
+case class Names(var __public: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this("", "")
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
-        _$$public
+        __public
       }.asInstanceOf[AnyRef]
       case 1 => {
         `ends_with_`
@@ -18,7 +18,7 @@ case class Names(var _$$public: String, var `ends_with_`: String) extends org.ap
   }
   def put(field$: Int, value: Any): Unit = {
     (field$: @switch) match {
-      case 0 => this._$$public = {
+      case 0 => this.__public = {
         value.toString
       }.asInstanceOf[String]
       case 1 => this.`ends_with_` = {

--- a/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
@@ -1,6 +1,6 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-case class Names(private val _$$public: String, `ends_with_`: String) {
-  val `public`: String = _$$public
+case class Names(private val __public: String, `ends_with_`: String) {
+  val `public`: String = __public
 }

--- a/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
@@ -1,6 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-case class Names(private val __public: String, `ends_with_`: String) {
-  val `public`: String = __public
-}
+case class Names(public$: String, `ends_with_`: String)

--- a/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
@@ -1,4 +1,6 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-case class Names(`public`: String, `ends_with_`: String)
+case class Names(private val _$$public: String, `ends_with_`: String) {
+  val `public`: String = _$$public
+}


### PR DESCRIPTION
This changes the names of a parameter, such as `public` into a mangled parameter, such as `_$$public`.

For case classes: it adds a public `val` to access it by the name given in the schema
For specific classes: the getter and setter should do the translating without changing the schema
For scavro: I am honestly not sure how it works :) or if it works :D

There are a few questionable things going on here:

1. I'm not sure `__` is a sufficient mangle or if it would be better to have something else.
2. The logic smells a bit funny, but not sure if there's a better way without refactoring a bunch of code.
3. ~~I'm not sure this actually works in real life, for all three cases. Yet.~~ Appears to work as expected, but not sure how to use the scavro classes in a real-life case.

This PR mostly exists to get your feedback on what I have.