### PR TITLE
Add support for Standard FIXED types

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ runtime, Java classes provided separately (see [Scavro Plugin](https://github.co
 |MAP|Map|Map|Map||
 |ENUM|scala.Enumeration<br>Scala case object<br>Java Enum<br>EnumAsScalaString|Java Enum<br>EnumAsScalaString|scala.Enumeration<br>Scala case object<br>Java Enum<br>EnumAsScalaString| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
 |BYTES|Array[Byte]<br>BigDecimal|Array[Byte]|Array[Byte]|See[Logical Types: `decimal`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
-|FIXED|//TODO|//TODO|//TODO||
+|FIXED|Array[Byte]|//TODO|//TODO||
 |ARRAY|Seq<br>List<br>Array<br>Vector|Seq<br>List<br>Array<br>Vector|Array<br>Seq<br>List<br>Vector| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
 |UNION|Option<br>Either<br>Shapeless Coproduct|Option|Option| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
 |RECORD|case class<br>case class + schema|case class extending `SpecificRecordBase`|case class extending `AvroSerializeable`| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|

--- a/avrohugger-core/src/main/scala-2.11/scala/jdk/package.scala
+++ b/avrohugger-core/src/main/scala-2.11/scala/jdk/package.scala
@@ -1,8 +1,0 @@
-package scala.jdk
-
-object CollectionConverters {
-
-  implicit class RichConcurrentHashMap[K,V](val javaMap: java.util.concurrent.ConcurrentHashMap[K,V]) {
-    def asScala = scala.collection.convert.Wrappers.JConcurrentMapWrapper(javaMap)
-  }
-}

--- a/avrohugger-core/src/main/scala-2.12/scala/jdk/package.scala
+++ b/avrohugger-core/src/main/scala-2.12/scala/jdk/package.scala
@@ -1,8 +1,0 @@
-package scala.jdk
-
-object CollectionConverters {
-
-  implicit class RichConcurrentHashMap[K,V](val javaMap: java.util.concurrent.ConcurrentHashMap[K,V]) {
-    def asScala = scala.collection.convert.Wrappers.JConcurrentMapWrapper(javaMap)
-  }
-}

--- a/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
@@ -198,7 +198,7 @@ trait SourceFormat {
       case RECORD => schema.getName
       case ENUM => schema.getName + "." + selector
       case FIXED => schema.getName
-      case _ => sys.error("Only RECORD and ENUM can be top-level definitions")
+      case _ => sys.error("Only RECORD or ENUM or FIXED can be top-level definitions")
     }
   }
   

--- a/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
@@ -8,7 +8,7 @@ import avrohugger.stores.{ ClassStore, SchemaStore }
 import avrohugger.types._
 
 import org.apache.avro.{ Protocol, Schema }
-import org.apache.avro.Schema.Type.{ ENUM, RECORD }
+import org.apache.avro.Schema.Type.{ ENUM, FIXED, RECORD }
 
 import java.nio.file.{ Path, Paths, Files, StandardOpenOption }
 import java.io.{ File, FileNotFoundException, IOException }
@@ -197,6 +197,7 @@ trait SourceFormat {
     schema.getType match {
       case RECORD => schema.getName
       case ENUM => schema.getName + "." + selector
+      case FIXED => schema.getName
       case _ => sys.error("Only RECORD and ENUM can be top-level definitions")
     }
   }

--- a/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardSchemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardSchemahugger.scala
@@ -10,7 +10,7 @@ import stores.{ClassStore, SchemaStore}
 import types._
 
 import org.apache.avro.{ Protocol, Schema }
-import org.apache.avro.Schema.Type.{ ENUM, RECORD }
+import org.apache.avro.Schema.Type.{ ENUM, FIXED, RECORD }
 
 import treehugger.forest._
 import definitions._
@@ -59,6 +59,7 @@ object StandardSchemahugger extends Schemahugger {
           List(objectDef)
         case EnumAsScalaString => List.empty
       }
+      case FIXED => List.empty
       case _ => sys.error("Only RECORD or ENUM can be toplevel definitions")
     }
   }

--- a/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardSchemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/standard/avrohuggers/StandardSchemahugger.scala
@@ -60,7 +60,7 @@ object StandardSchemahugger extends Schemahugger {
         case EnumAsScalaString => List.empty
       }
       case FIXED => List.empty
-      case _ => sys.error("Only RECORD or ENUM can be toplevel definitions")
+      case _ => sys.error("Only RECORD or ENUM or FIXED can be toplevel definitions")
     }
   }
 

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -61,7 +61,7 @@ class TypeMatcher(
             default = StringClass) {
             case UUID => RootClass.newClass(nme.createNameType("java.util.UUID"))
           }
-        case Schema.Type.FIXED    => sys.error("FIXED datatype not yet supported")
+        case Schema.Type.FIXED    => CustomTypeMatcher.checkCustomDecimalType(avroScalaTypes.decimal, schema)
         case Schema.Type.BYTES    => CustomTypeMatcher.checkCustomDecimalType(avroScalaTypes.decimal, schema)
         case Schema.Type.RECORD   => classStore.generatedClasses(schema)
         case Schema.Type.ENUM     => CustomTypeMatcher.checkCustomEnumType(avroScalaTypes.enum, classStore, schema)

--- a/avrohugger-core/src/main/scala/stores/ClassStore.scala
+++ b/avrohugger-core/src/main/scala/stores/ClassStore.scala
@@ -6,7 +6,7 @@ import org.apache.avro.Schema
 import treehugger.forest.Symbol
 
 import java.util.concurrent.ConcurrentHashMap
-import scala.jdk.CollectionConverters._
+import collection.JavaConverters._
 
 class ClassStore {
 

--- a/avrohugger-core/src/main/scala/stores/SchemaStore.scala
+++ b/avrohugger-core/src/main/scala/stores/SchemaStore.scala
@@ -4,7 +4,7 @@ package stores
 import org.apache.avro.Schema
 
 import java.util.concurrent.ConcurrentHashMap
-import scala.jdk.CollectionConverters._
+import collection.JavaConverters._
 
 class SchemaStore {
 

--- a/avrohugger-core/src/main/scala/stores/TypecheckDependencyStore.scala
+++ b/avrohugger-core/src/main/scala/stores/TypecheckDependencyStore.scala
@@ -4,7 +4,7 @@ package stores
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.reflect.runtime.universe._
-import scala.jdk.CollectionConverters._
+import collection.JavaConverters._
 
 class TypecheckDependencyStore {
 

--- a/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala
+++ b/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala
@@ -31,6 +31,7 @@ object LogicalType {
     case _: org.apache.avro.LogicalTypes.Date => Some(Date)
     case _: org.apache.avro.LogicalTypes.TimestampMillis => Some(TimestampMillis)
     case _ if logicalType.getName == "uuid" => Some(UUID)
+    case _ if logicalType.getName == "fixed" => sys.error("TODO")
     case _ => None
   }
   

--- a/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala
+++ b/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala
@@ -31,7 +31,6 @@ object LogicalType {
     case _: org.apache.avro.LogicalTypes.Date => Some(Date)
     case _: org.apache.avro.LogicalTypes.TimestampMillis => Some(TimestampMillis)
     case _ if logicalType.getName == "uuid" => Some(UUID)
-    case _ if logicalType.getName == "fixed" => sys.error("TODO")
     case _ => None
   }
   

--- a/avrohugger-core/src/test/avro/fixed.avdl
+++ b/avrohugger-core/src/test/avro/fixed.avdl
@@ -1,0 +1,11 @@
+@namespace("example.idl")
+
+protocol FixedIDL {
+
+  fixed my_fixed(16);
+
+  record FixedIdl {
+
+    my_fixed data;
+  }
+}

--- a/avrohugger-core/src/test/avro/fixed.avsc
+++ b/avrohugger-core/src/test/avro/fixed.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "FixedSc",
+  "namespace": "example",
+  "fields": [
+    {
+      "name": "data",
+      "type": {
+        "type": "fixed",
+        "name": "my_fixed",
+        "size": 16
+      }
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/standard/example/FixedSc.scala
+++ b/avrohugger-core/src/test/expected/standard/example/FixedSc.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example
+
+final case class FixedSc(data: Array[Byte])

--- a/avrohugger-core/src/test/expected/standard/example/idl/FixedIdl.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/FixedIdl.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package example.idl
+
+final case class FixedIdl(data: Array[Byte])

--- a/avrohugger-core/src/test/scala/standard/StandardStringToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardStringToFileSpec.scala
@@ -28,7 +28,8 @@ class StandardStringToFileSpec extends Specification {
       correctly generate records depending on others defined in a different- and same-namespaced AVDL and AVSC $e14
       correctly generate an empty case class definition $e15
       correctly generate default values $e16
-
+      correctly generate fixed from schema $e17
+      correctly generate fixed from IDL $e18
 
 
 
@@ -233,6 +234,28 @@ class StandardStringToFileSpec extends Specification {
     val adt = util.Util.readFile("target/generated-sources/standard/example/idl/Defaults.scala")
 
     adt === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/Defaults.scala")
+  }
+
+  def e17 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/fixed.avsc")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.stringToFile(inputString, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/FixedSc.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/FixedSc.scala")
+  }
+
+  def e18 = {
+    val inputString = util.Util.readFile("avrohugger-core/src/test/avro/fixed.avdl")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.stringToFile(inputString, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/idl/FixedIdl.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/FixedIdl.scala")
   }
 
   def e21 = {


### PR DESCRIPTION
Hi,

this PR partially resolves https://github.com/julianpeeters/sbt-avrohugger/issues/53 and https://github.com/julianpeeters/avrohugger/issues/84

```
[error] java.lang.RuntimeException: FIXED datatype not yet supported
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at avrohugger.matchers.TypeMatcher.matchType$1(TypeMatcher.scala:64)
[error] 	at avrohugger.matchers.TypeMatcher.$anonfun$toScalaType$4(TypeMatcher.scala:71)
[error] 	at avrohugger.matchers.TypeMatcher.unionsArityStrategy$1(TypeMatcher.scala:123)
[error] 	at avrohugger.matchers.TypeMatcher.unionTypeImpl(TypeMatcher.scala:132)
[error] 	at avrohugger.matchers.TypeMatcher.matchType$1(TypeMatcher.scala:71)
[error] 	at avrohugger.matchers.TypeMatcher.toScalaType(TypeMatcher.scala:77)
[error] 	at avrohugger.format.standard.trees.StandardCaseClassTree$.$anonfun$toCaseClassDef$1(StandardCaseClassTree.scala:39)
[error] 	at scala.collection.immutable.List.map(List.scala:297)
[error] 	at avrohugger.format.standard.trees.StandardCaseClassTree$.toCaseClassDef(StandardCaseClassTree.scala:37)
[error] 	at avrohugger.format.standard.avrohuggers.StandardSchemahugger$.toTrees(StandardSchemahugger.scala:40)
[error] 	at avrohugger.format.standard.StandardScalaTreehugger$.asScalaCodeString(StandardScalaTreehugger.scala:45)
[error] 	at avrohugger.format.abstractions.SourceFormat.getScalaCompilationUnit(SourceFormat.scala:168)
[error] 	at avrohugger.format.abstractions.SourceFormat.getScalaCompilationUnit$(SourceFormat.scala:152)
[error] 	at avrohugger.format.Standard$.getScalaCompilationUnit(Standard.scala:18)
[error] 	at avrohugger.format.Standard$.asCompilationUnits(Standard.scala:55)
[error] 	at avrohugger.format.Standard$.compile(Standard.scala:155)
[error] 	at avrohugger.generators.FileGenerator$.$anonfun$schemaToFile$1(FileGenerator.scala:35)
[error] 	at avrohugger.generators.FileGenerator$.$anonfun$schemaToFile$1$adapted(FileGenerator.scala:32)
[error] 	at scala.collection.immutable.List.foreach(List.scala:431)
[error] 	at avrohugger.generators.FileGenerator$.schemaToFile(FileGenerator.scala:32)
[error] 	at avrohugger.generators.FileGenerator$.$anonfun$fileToFile$1(FileGenerator.scala:87)
[error] 	at avrohugger.generators.FileGenerator$.$anonfun$fileToFile$1$adapted(FileGenerator.scala:85)
[error] 	at scala.collection.immutable.List.foreach(List.scala:431)
[error] 	at avrohugger.generators.FileGenerator$.fileToFile(FileGenerator.scala:85)
[error] 	at avrohugger.Generator.fileToFile(Generator.scala:76)
[error] 	at sbtavrohugger.FileWriter$.$anonfun$generateCaseClasses$4(FileWriter.scala:26)
[error] 	at sbtavrohugger.FileWriter$.$anonfun$generateCaseClasses$4$adapted(FileWriter.scala:24)
[error] 	at scala.collection.LinearSeqOptimized.foreach(LinearSeqOptimized.scala:75)
[error] 	at scala.collection.LinearSeqOptimized.foreach$(LinearSeqOptimized.scala:72)
[error] 	at scala.collection.mutable.MutableList.foreach(MutableList.scala:33)
[error] 	at sbtavrohugger.FileWriter$.generateCaseClasses(FileWriter.scala:24)
[error] 	at sbtavrohugger.SbtAvrohugger$.$anonfun$avroSettings$9(SbtAvrohugger.scala:92)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$1(FileFunction.scala:80)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$4(FileFunction.scala:153)
[error] 	at sbt.util.Difference.apply(Tracked.scala:414)
[error] 	at sbt.util.Difference.apply(Tracked.scala:394)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$3(FileFunction.scala:149)
[error] 	at sbt.util.Difference.apply(Tracked.scala:414)
[error] 	at sbt.util.Difference.apply(Tracked.scala:389)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$2(FileFunction.scala:148)
[error] 	at sbtavrohugger.SbtAvrohugger$.$anonfun$avroSettings$7(SbtAvrohugger.scala:95)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:834)
[error] (app / Compile / avroScalaGenerate) FIXED datatype not yet supported
```

It also fixes #131 which was blocking, currently the only way was to downgrade the lib to resolve the following error

```
[error] java.lang.NoSuchMethodError: 'scala.jdk.CollectionConverters$RichConcurrentHashMap scala.jdk.CollectionConverters$.RichConcurrentHashMap(java.util.concurrent.ConcurrentHashMap)'
[error] 	at avrohugger.stores.ClassStore.<init>(ClassStore.scala:14)
[error] 	at avrohugger.Generator.<init>(Generator.scala:25)
[error] 	at sbtavrohugger.SbtAvrohugger$.$anonfun$avroSettings$9(SbtAvrohugger.scala:91)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$1(FileFunction.scala:80)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$4(FileFunction.scala:153)
[error] 	at sbt.util.Difference.apply(Tracked.scala:414)
[error] 	at sbt.util.Difference.apply(Tracked.scala:394)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$3(FileFunction.scala:149)
[error] 	at sbt.util.Difference.apply(Tracked.scala:414)
[error] 	at sbt.util.Difference.apply(Tracked.scala:389)
[error] 	at sbt.util.FileFunction$.$anonfun$cached$2(FileFunction.scala:148)
[error] 	at sbtavrohugger.SbtAvrohugger$.$anonfun$avroSettings$7(SbtAvrohugger.scala:95)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:834)
[error] (app / Compile / avroScalaGenerate) java.lang.NoSuchMethodError: 'scala.jdk.CollectionConverters$RichConcurrentHashMap scala.jdk.CollectionConverters$.RichConcurrentHashMap(java.util.concurrent.ConcurrentHashMap)'
```

`import collection.JavaConverters._` is deprecated and not ideal, but at least it doesn't cause cross compilation errors

I run the tests both for `avrohugger` and `sbt-avrohugger` like explained in the readme

FYI in `avrohugger` this test is flaky, but I run them multiple times and I got this error only once, so I think it's ok
```
[error] Error: Total 353, Failed 1, Errors 1, Passed 351
[error] Failed tests:
[error] 	avrohugger.test.scavro.ScavroFileToFileSpec
[error] Error during tests:
[error] 	avrohugger.test.standard.StandardManyFieldsSpec
[error] (avrohugger-core / Test / test) sbt.TestsFailedException: Tests unsuccessful
```

There are 3 tests failing on the sbt plugin, but I doubt they are actual errors... could you please verify?

```
[error] java.lang.RuntimeException: Failed tests:
[error] 	avrohugger / SpecificADTSerializationTests
[error] 	avrohugger / SpecificStringEnumSerializationTests
[error] 	avrohugger / SpecificSerializationTests
[error]
[error] 	at scala.sys.package$.error(package.scala:26)
[error] 	at sbt.scriptedtest.ScriptedRunner.reportErrors(ScriptedTests.scala:560)
[error] 	at sbt.scriptedtest.ScriptedRunner.runAll(ScriptedTests.scala:563)
[error] 	at sbt.scriptedtest.ScriptedRunner.run(ScriptedTests.scala:508)
[error] 	at sbt.scriptedtest.ScriptedRunner.run(ScriptedTests.scala:472)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error] 	at sbt.ScriptedPlugin$.$anonfun$scriptedTask$3(ScriptedPlugin.scala:185)
[error] 	at sbt.ScriptedPlugin$.$anonfun$scriptedTask$3$adapted(ScriptedPlugin.scala:170)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:834)
[error] (scripted) Failed tests:
[error] 	avrohugger / SpecificADTSerializationTests
[error] 	avrohugger / SpecificStringEnumSerializationTests
[error] 	avrohugger / SpecificSerializationTests
[error] Total time: 1047 s, completed 24 Nov 2020, 11:35:21
```

They all fail for this error on `2.11.x`, which I'm not sure how to resolve 😅 

```
[info] [info] Non-compiled module 'compiler-bridge_2.11' for Scala 2.11.11. Compiling...
[error] error: scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found.
[error] 	at scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:17)
[error] 	at scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:18)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:53)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:45)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:45)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:66)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getClassByName(Mirrors.scala:102)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getRequiredClass(Mirrors.scala:105)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.ObjectClass$lzycompute(Definitions.scala:257)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.ObjectClass(Definitions.scala:257)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1390)
[error] 	at scala.tools.nsc.Global$Run.<init>(Global.scala:1242)
[error] 	at scala.tools.nsc.Driver.doCompile(Driver.scala:31)
[error] 	at scala.tools.nsc.MainClass.doCompile(Main.scala:23)
[error] 	at scala.tools.nsc.Driver.process(Driver.scala:51)
[error] 	at scala.tools.nsc.Main.process(Main.scala)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error] 	at sbt.internal.inc.RawCompiler.getReporter$1(RawCompiler.scala:50)
[error] 	at sbt.internal.inc.RawCompiler.apply(RawCompiler.scala:71)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$6(AnalyzingCompiler.scala:350)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.handleCompilationError$1(AnalyzingCompiler.scala:327)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$4(AnalyzingCompiler.scala:346)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$4$adapted(AnalyzingCompiler.scala:341)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:475)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:482)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$2(AnalyzingCompiler.scala:341)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$2$adapted(AnalyzingCompiler.scala:335)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:475)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:482)
[error] 	at sbt.internal.inc.AnalyzingCompiler$.compileSources(AnalyzingCompiler.scala:335)
[error] 	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$3(ZincComponentCompiler.scala:277)
[error] 	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$3$adapted(ZincComponentCompiler.scala:262)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:475)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:482)
[error] 	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$2(ZincComponentCompiler.scala:262)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error] 	at sbt.internal.util.BufferedLogger.bufferQuietly(BufferedLogger.scala:106)
[error] 	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$1(ZincComponentCompiler.scala:262)
[error] 	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$1$adapted(ZincComponentCompiler.scala:259)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:475)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:482)
[error] 	at sbt.internal.inc.ZincComponentCompiler.compileAndInstall(ZincComponentCompiler.scala:259)
[error] 	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compiledBridgeJar$1(ZincComponentCompiler.scala:225)
[error] 	at sbt.internal.inc.IfMissing$Define.run(IfMissing.scala:19)
[error] 	at sbt.internal.inc.ZincComponentManager.createAndCache$1(ZincComponentManager.scala:46)
[error] 	at sbt.internal.inc.ZincComponentManager.$anonfun$files$3(ZincComponentManager.scala:57)
[error] 	at sbt.internal.inc.ZincComponentManager.getOrElse$1(ZincComponentManager.scala:38)
[error] 	at sbt.internal.inc.ZincComponentManager.$anonfun$files$2(ZincComponentManager.scala:57)
[error] 	at sbt.internal.inc.ZincComponentManager$$anon$1.call(ZincComponentManager.scala:87)
[error] 	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:95)
[error] 	at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:80)
[error] 	at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:99)
[error] 	at xsbt.boot.Using$.withResource(Using.scala:10)
[error] 	at xsbt.boot.Using$.apply(Using.scala:9)
[error] 	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:60)
[error] 	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:50)
[error] 	at xsbt.boot.Locks$.apply0(Locks.scala:31)
[error] 	at xsbt.boot.Locks$.apply(Locks.scala:28)
[error] 	at sbt.internal.inc.ZincComponentManager.lock(ZincComponentManager.scala:87)
[error] 	at sbt.internal.inc.ZincComponentManager.$anonfun$lockSecondaryCache$1(ZincComponentManager.scala:84)
[error] 	at scala.Option.map(Option.scala:146)
[error] 	at sbt.internal.inc.ZincComponentManager.lockSecondaryCache(ZincComponentManager.scala:82)
[error] 	at sbt.internal.inc.ZincComponentManager.fromSecondary$1(ZincComponentManager.scala:55)
[error] 	at sbt.internal.inc.ZincComponentManager.$anonfun$files$6(ZincComponentManager.scala:61)
[error] 	at sbt.internal.inc.ZincComponentManager.getOrElse$1(ZincComponentManager.scala:38)
[error] 	at sbt.internal.inc.ZincComponentManager.$anonfun$files$5(ZincComponentManager.scala:61)
[error] 	at sbt.internal.inc.ZincComponentManager$$anon$1.call(ZincComponentManager.scala:87)
[error] 	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:95)
[error] 	at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:80)
[error] 	at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:99)
[error] 	at xsbt.boot.Using$.withResource(Using.scala:10)
[error] 	at xsbt.boot.Using$.apply(Using.scala:9)
[error] 	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:60)
[error] 	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:50)
[error] 	at xsbt.boot.Locks$.apply0(Locks.scala:31)
[error] 	at xsbt.boot.Locks$.apply(Locks.scala:28)
[error] 	at sbt.internal.inc.ZincComponentManager.lock(ZincComponentManager.scala:87)
[error] 	at sbt.internal.inc.ZincComponentManager.lockLocalCache(ZincComponentManager.scala:78)
[error] 	at sbt.internal.inc.ZincComponentManager.files(ZincComponentManager.scala:61)
[error] 	at sbt.internal.inc.ZincComponentManager.file(ZincComponentManager.scala:66)
[error] 	at sbt.internal.inc.ZincComponentCompiler.compiledBridgeJar(ZincComponentCompiler.scala:225)
[error] 	at sbt.internal.inc.ZincComponentCompiler$ZincCompilerBridgeProvider.compiledBridge(ZincComponentCompiler.scala:83)
[error] 	at sbt.internal.inc.ZincComponentCompiler$ZincCompilerBridgeProvider.fetchCompiledBridge(ZincComponentCompiler.scala:90)
[error] 	at sbt.internal.inc.AnalyzingCompiler.loader(AnalyzingCompiler.scala:249)
[error] 	at sbt.internal.inc.AnalyzingCompiler.getInterfaceClass(AnalyzingCompiler.scala:267)
[error] 	at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:234)
[error] 	at sbt.internal.inc.AnalyzingCompiler.newCachedCompiler(AnalyzingCompiler.scala:134)
[error] 	at sbt.internal.inc.AnalyzingCompiler.newCachedCompiler(AnalyzingCompiler.scala:121)
[error] 	at sbt.internal.inc.FreshCompilerCache.apply(CompilerCache.scala:78)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:88)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:82)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:133)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:73)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:116)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:307)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:307)
[error] 	at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:106)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:87)
[error] 	at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:116)
[error] 	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:63)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:89)
[error] 	at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:134)
[error] 	at sbt.internal.inc.Incremental$.compile(Incremental.scala:80)
[error] 	at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:67)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:311)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:269)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:159)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:238)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:69)
[error] 	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1549)
[error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1523)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:834)
[info] [info] Attempting to fetch org.scala-sbt:compiler-bridge_2.11:1.2.5.
[info] [error] (Compile / compileIncremental) Error compiling the sbt component 'compiler-bridge_2.11'
[info] [error] Total time: 1 s, completed 24 Nov 2020, 11:27:49
```

Please let me know if there is anything that can be improved or if it's good to be merged and you are happy to release `1.0.0-RC23`, I'm currently working with a published version locally, which is not ideal... 🙄 

Thanks!