### PR TITLE
Fix #147 - Use a separate temp directory

### DIFF
--- a/avrohugger-core/src/main/scala/format/scavro/ScavroJavaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroJavaTreehugger.scala
@@ -4,21 +4,9 @@ package scavro
 
 import format.abstractions.JavaTreehugger
 import stores.ClassStore
+import org.apache.avro.Schema
 
-import treehugger.forest._
-import definitions._
-import treehuggerDSL._
-
-import java.io.{
-  File,
-  BufferedWriter,
-  FileWriter,
-  FileNotFoundException,
-  IOException
-}
-
-import org.apache.avro.{ Protocol, Schema }
-import org.apache.avro.compiler.specific.SpecificCompiler
+import java.nio.file.{FileSystems, Files, Path}
 
 
 object ScavroJavaTreehugger extends JavaTreehugger {
@@ -28,61 +16,11 @@ object ScavroJavaTreehugger extends JavaTreehugger {
     namespace: Option[String],
     schema: Schema): String = {
 
-    def writeJavaTempFile(
-      namespace: Option[String],
-      schema: Schema, outDir: String): Unit = {
-	    // Uses Avro's SpecificCompiler, which only compiles from files, thus we 
-      // write the schema to a temp file so we can compile a Java enum from it.
-	    val tempSchemaFile = File.createTempFile(schema.getName, ".avsc")
-	    tempSchemaFile.deleteOnExit()
-	    val out = new BufferedWriter(new FileWriter(tempSchemaFile))
-	    out.write(schema.toString)
-	    out.close()
-
-	    val folderPath = {
-	      if (namespace.isDefined) new File(outDir)
-	      else new File(outDir) 
-	    }
-	    try { 
-	      SpecificCompiler.compileSchema(tempSchemaFile, folderPath)
-	    }     
-	    catch {
-	      case ex: FileNotFoundException =>
-          sys.error("File not found:" + ex)
-	      case ex: IOException =>
-          sys.error("There was a problem using the file: " + ex)
-	    }
-	  }
-
-    def deleteTemps(path: String) = {
-      val penultimateFile = new File(path.split('/').take(2).mkString("/"))
-      def getFiles(f: File): Set[File] = {
-        Option(f.listFiles)
-          .map(a => a.toSet)
-          .getOrElse(Set.empty)
-      }
-      def getRecursively(f: File): Set[File] = {
-        val files = getFiles(f)
-        val subDirectories = files.filter(path => path.isDirectory)
-        subDirectories.flatMap(getRecursively) ++ files + penultimateFile
-      }
-      def sortByDepth(f1: File, f2: File) = {
-        def countLevels(f: File) = f.getAbsolutePath.count(c => c == '/')
-        countLevels(f1) > countLevels(f2)
-      }
-      val filesToDelete = getRecursively(penultimateFile)
-      val sortedFilesToDelete = filesToDelete.toList.sortWith(sortByDepth)
-      sortedFilesToDelete.foreach(file => {
-        if (getFiles(file).isEmpty) file.deleteOnExit
-      })
-    }
-
     // Avro's SpecificCompiler only writes files, but we need a string
     // so write the Java file and read
-    val outDir = System.getProperty("java.io.tmpdir")
-    writeJavaTempFile(namespace, schema, outDir)
-    val tempPath = outDir + "/" +  schema.getFullName.replace('.','/') + ".java"
-    val tempFile = new File(tempPath)
+    val tempDir = createTempDir("avrohugger_scavro")
+    writeJavaTempFile(schema, tempDir)
+    val tempPath = tempDir + "/" +  schema.getFullName.replace('.','/') + ".java"
     val fileContents = scala.io.Source.fromFile(tempPath)
     val schemaPackage = "package " + schema.getNamespace
     val updatedPackage = namespace match {
@@ -98,7 +36,7 @@ object ScavroJavaTreehugger extends JavaTreehugger {
       .replace(schemaPackage, updatedPackage)
       .replace(schemaNamespace, updatedNamespace)
     fileContents.close
-    deleteTemps(tempPath)
+    deleteTempDirOnExit(tempDir)
     codeString
   }
 

--- a/avrohugger-core/src/main/scala/format/specific/SpecificJavaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/specific/SpecificJavaTreehugger.scala
@@ -4,21 +4,15 @@ package specific
 
 import format.abstractions.JavaTreehugger
 import stores.ClassStore
-
 import treehugger.forest._
 import definitions._
 import treehuggerDSL._
 
-import java.io.{
-  File,
-  BufferedWriter,
-  FileWriter,
-  FileNotFoundException,
-  IOException
-}
-
-import org.apache.avro.{ Protocol, Schema }
+import java.io.{BufferedWriter, File, FileNotFoundException, FileWriter, IOException}
+import org.apache.avro.{Protocol, Schema}
 import org.apache.avro.compiler.specific.SpecificCompiler
+
+import java.nio.file.{FileSystems, Files, Path}
 
 object SpecificJavaTreehugger extends JavaTreehugger {
 
@@ -27,62 +21,11 @@ object SpecificJavaTreehugger extends JavaTreehugger {
     namespace: Option[String],
     schema: Schema): String = {
 
-    def writeJavaTempFile(
-      namespace: Option[String],
-      schema: Schema,
-      outDir: String): Unit = {
-	    // Uses Avro's SpecificCompiler, which only compiles from files, thus we 
-      // write the schema to a temp file so we can compile a Java enum from it.
-	    val tempSchemaFile = File.createTempFile(outDir + "/" + schema.getName, ".avsc")
-	    tempSchemaFile.deleteOnExit()
-	    val out = new BufferedWriter(new FileWriter(tempSchemaFile))
-	    out.write(schema.toString)
-	    out.close()
-
-	    val folderPath = {
-	      if (namespace.isDefined) new File(outDir)
-	      else new File(outDir) 
-	    }
-	    try { 
-	      SpecificCompiler.compileSchema(tempSchemaFile, folderPath)
-	    }     
-	    catch {
-	      case ex: FileNotFoundException =>
-          sys.error("File not found:" + ex)
-	      case ex: IOException =>
-          sys.error("There was a problem using the file: " + ex)
-	    }
-	  }
-
-    def deleteTemps(path: String) = {
-      val penultimateFile = new File(path.split('/').take(2).mkString("/"))
-      def getFiles(f: File): Set[File] = {
-        Option(f.listFiles)
-          .map(a => a.toSet)
-          .getOrElse(Set.empty)
-      }
-      def getRecursively(f: File): Set[File] = {
-        val files = getFiles(f)
-        val subDirectories = files.filter(path => path.isDirectory)
-        subDirectories.flatMap(getRecursively) ++ files + penultimateFile
-      }
-      def sortByDepth(f1: File, f2: File) = {
-        def countLevels(f: File) = f.getAbsolutePath.count(c => c == '/')
-        countLevels(f1) > countLevels(f2)
-      }
-      val filesToDelete = getRecursively(penultimateFile)
-      val sortedFilesToDelete = filesToDelete.toList.sortWith(sortByDepth)
-      sortedFilesToDelete.foreach(file => {
-        if (getFiles(file).isEmpty) file.deleteOnExit
-      })
-    }
-
     // Avro's SpecificCompiler only writes files, but we need a string
     // so write the Java file and read
-    val outDir = System.getProperty("java.io.tmpdir")
-    writeJavaTempFile(namespace, schema, outDir)
-    val tempPath = outDir + "/" + schema.getFullName.replace('.','/') + ".java"
-    val tempFile = new File(tempPath)
+    val tempDir = createTempDir("avrohugger_specific")
+    writeJavaTempFile(schema, tempDir)
+    val tempPath = tempDir + "/" + schema.getFullName.replace('.','/') + ".java"
     val fileContents = scala.io.Source.fromFile(tempPath)
     val schemaPackage = "package " + schema.getNamespace
     val updatedPackage = namespace match {
@@ -98,7 +41,7 @@ object SpecificJavaTreehugger extends JavaTreehugger {
       .replace(schemaPackage, updatedPackage)
       .replace(schemaNamespace, updatedNamespace)
     fileContents.close
-    deleteTemps(tempPath)
+    deleteTempDirOnExit(tempDir)
     codeString
   }
 

--- a/avrohugger-core/src/main/scala/generators/StringGenerator.scala
+++ b/avrohugger-core/src/main/scala/generators/StringGenerator.scala
@@ -84,7 +84,7 @@ private[avrohugger] object StringGenerator {
       }
     }).distinct
     // reset the schema store after processing the whole submission
-    schemaStore.schemas.clear
+    schemaStore.schemas.clear()
     codeStrings
   }
 


### PR DESCRIPTION
## Problem Description

We're having an issue with deleted files after the build with `sbt-avrohugger`.
It seems, after the build some directories get deleted that shouldn't.

From what I could understand, the original path before a49e5f6 was relative (`target`).
Now in our build, we pass this directory absolute, eg. (`/path/to/build`).

The issue we encountered was the following:
The method `deleteTemps` deletes all files in the penultimate file of this path (in above example `/path/to`), that have no children - this seems to apply to all files as well as empty directories

## Description of changes

I've taken the following actions, to avoid this in the future:
* Create a temporary directory, which contains the generated files
* Write the generated files to this directory
* Delete all the contents of this directory afterwards

## Steps to reproduce this issue:

**1. Create the temporary directory structure**

```sh
mkdir -p /tmp/poc/java_tmp
touch /tmp/poc/foo
touch /tmp/poc/bar
touch /tmp/poc/baz
find /tmp/poc
# /tmp/poc
# /tmp/poc/java_tmp
# /tmp/poc/foo
# /tmp/poc/baz
# /tmp/poc/bar
```

**2. Run the build (for example with sbt-avrohugger 2.0.0-RC24)**

`SBT_OPTS="-Djava.io.tmpdir=/tmp/poc/java_tmp" sbt clean compile`

**3. Verify the outcome**

```sh
find /tmp/poc
# /tmp/poc
# /tmp/poc/java_tmp
# /tmp/poc/java_tmp/my
# /tmp/poc/java_tmp/my/namespace
# /tmp/poc/java_tmp/my/namespace/name
```

Note that `foo`, `bar` and `baz` have been deleted.

## Workaround

In my case I downgraded to `2.0.0-RC15`, which didn't have this issue yet it seems.

## Final note

I would urge users not to use the versions from `2.0.0-RC16` up to `2.0.0-RC24`, because they can actually damage your system (if the permissions allow it).
For example, if I were to set `-Djava.io.tmpdir=/home/myuser/.java_tmp` it could wipe out my home directory.

Just a heads up!