### PR TITLE
fix julianpeeters/sbt-avrohugger#86 - case class property escaping

### DIFF
--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -2,20 +2,14 @@ package avrohugger
 package format
 
 object FieldRenamer {
-  val RESERVED_WORDS: Set[String] = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch",
-    "char", "class", "const", "continue", "default", "do", "double",
-    "else", "enum", "extends", "false", "final", "finally", "float",
-    "for", "goto", "if", "implements", "import", "instanceof", "int",
-    "interface", "long", "native", "new", "null", "package", "private",
-    "protected", "public", "return", "short", "static", "strictfp",
-    "super", "switch", "synchronized", "this", "throw", "throws",
-    "transient", "true", "try", "void", "volatile", "while")
+  // Reserved words from https://www.scala-lang.org/files/archive/spec/2.13/01-lexical-syntax.html#identifiers
+  private val RESERVED_WORDS: Set[String] = Set("abstract", "case", "catch", "class", "def", "do", "else", "extends", "final", "finally",
+    "for", "forSome", "if", "implicit", "lazy", "macro", "match", "new", "object", "override", "package", "private", "protected", "return",
+    "sealed", "super", "this", "throw", "trait", "try", "type", "val", "var", "while", "with", "yield")
 
-  def backtick(variable: String): String = s"`$variable`"
+  private def backtick(variable: String): String = s"`$variable`"
 
-  def mangle(variable: String): String = variable + "$"
+  private def isMangled(fieldName: String): Boolean = RESERVED_WORDS.contains(fieldName) || fieldName.endsWith("_")
 
-  def isMangled(fieldName: String): Boolean = RESERVED_WORDS.contains(fieldName)
-
-  def rename(fieldName: String): String = if(isMangled(fieldName)) mangle(fieldName) else if (fieldName.endsWith("_")) backtick(fieldName) else fieldName
+  def rename(fieldName: String): String = if (isMangled(fieldName)) backtick(fieldName) else fieldName
 }

--- a/avrohugger-core/src/test/avro/special_names.avdl
+++ b/avrohugger-core/src/test/avro/special_names.avdl
@@ -2,7 +2,7 @@
 protocol SpecialNames {
 
   record Names {
-    string `public`;
+    string `protected`;
     string `ends_with_`;
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
@@ -7,10 +7,10 @@ import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
 import example.idl.{Names => JNames}
 
-final case class Names(public$: String, `ends_with_`: String) extends AvroSerializeable {
+final case class Names(`protected`: String, `ends_with_`: String) extends AvroSerializeable {
   type J = JNames
   override def toAvro: JNames = {
-    new JNames(public$, `ends_with_`)
+    new JNames(`protected`, `ends_with_`)
   }
 }
 
@@ -22,7 +22,7 @@ object Names {
     override val avroClass: Class[JNames] = classOf[JNames]
     override val schema: Schema = JNames.getClassSchema()
     override val fromAvro: (JNames) => Names = {
-      (j: JNames) => Names(j.getPublic$.toString, j.getEndsWith.toString)
+      (j: JNames) => Names(j.getProtected$.toString, j.getEndsWith.toString)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
@@ -3,12 +3,12 @@ package example.idl
 
 import scala.annotation.switch
 
-final case class Names(var public$: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
+final case class Names(var `protected`: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this("", "")
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
-        public$
+        `protected`
       }.asInstanceOf[AnyRef]
       case 1 => {
         `ends_with_`
@@ -18,7 +18,7 @@ final case class Names(var public$: String, var `ends_with_`: String) extends or
   }
   def put(field$: Int, value: Any): Unit = {
     (field$: @switch) match {
-      case 0 => this.public$ = {
+      case 0 => this.`protected` = {
         value.toString
       }.asInstanceOf[String]
       case 1 => this.`ends_with_` = {
@@ -32,5 +32,5 @@ final case class Names(var public$: String, var `ends_with_`: String) extends or
 }
 
 object Names {
-  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Names\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"public\",\"type\":\"string\"},{\"name\":\"ends_with_\",\"type\":\"string\"}]}")
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Names\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"protected\",\"type\":\"string\"},{\"name\":\"ends_with_\",\"type\":\"string\"}]}")
 }

--- a/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-final case class Names(public$: String, `ends_with_`: String)
+final case class Names(`protected`: String, `ends_with_`: String)


### PR DESCRIPTION
Fix property mangling in generated case classes:
- only scala reserved keywords are mangled,
- mangling is now only backticks instead of appending $