### PR TITLE
Add support for logical type time-millis

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _NOTE: Currently logical types are only supported for `Standard` and `SpecificRe
 * `decimal`: Annotates Avro `bytes` and `fixed` schemas to generate `BigDecimal`. Examples: [avdl](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avdl#L6), [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L6-L14).
 * `timestamp-millis`: Annotates Avro `long` schemas to genarate `java.time.Instant` or `java.sql.Timestamp` (See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)). Examples: [avdl](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avdl#L8), [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L15-L21).
 * `uuid`: Annotates Avro `string` schemas (but not idls as of avro 1.8.2) to generate `java.util.UUID` (See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)). Example: [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L29-L35).
+* `time-millis`: Annotates Avro `int` schemas to genarate `java.time.LocalTime` or `java.sql.Time`
 
 ##### Protocol Support:
 

--- a/avrohugger-core/src/main/scala/format/specific/converters/JavaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/specific/converters/JavaConverter.scala
@@ -169,6 +169,10 @@ object JavaConverter {
         case JavaSqlDate       => tree.DOT("getTime").APPLY().DOT("/").APPLY(LIT(86400000))
         case JavaTimeLocalDate => tree.DOT("toEpochDay").DOT("toInt")
       }
+      case timeMillis: LogicalTypes.TimeMillis => typeMatcher.avroScalaTypes.timeMillis match {
+        case JavaSqlTime       => tree.DOT("getTime").APPLY()
+        case JavaTimeLocalTime => tree.DOT("get").APPLY(REF("java.time.temporal.ChronoField").DOT("MILLI_OF_DAY"))
+      }
       case _ => tree
     }
     case Schema.Type.STRING =>

--- a/avrohugger-core/src/main/scala/format/specific/converters/ScalaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/specific/converters/ScalaConverter.scala
@@ -247,7 +247,24 @@ object ScalaConverter {
                   tree MATCH integerConversion
                 }
               }
-
+            }
+            else if (logicalType.getName == "time-millis") {
+              typeMatcher.avroScalaTypes.timeMillis match {
+                case JavaSqlTime => {
+                  val IntegerClass = RootClass.newClass("Integer")
+                  val SqlTimeClass = RootClass.newClass("java.sql.Time")
+                  val resultExpr = BLOCK(NEW(SqlTimeClass, REF("i").DOT("toLong")))
+                  val integerConversion = CASE(ID("i") withType (IntegerClass)) ==> resultExpr
+                  tree MATCH integerConversion
+                }
+                case JavaTimeLocalTime => {
+                  val IntegerClass = RootClass.newClass("Integer")
+                  val LocalTimeClass = RootClass.newClass("java.time.LocalTime")
+                  val resultExpr = BLOCK(LocalTimeClass.DOT("ofNanoOfDay").APPLY(REF("i").INFIX("*", LIT(1000000L))))
+                  val integerConversion = CASE(ID("i") withType (IntegerClass)) ==> resultExpr
+                  tree MATCH integerConversion
+                }
+              }
             }
             else tree
           }

--- a/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
@@ -30,6 +30,10 @@ object DefaultParamMatcher {
           case Date =>
             CustomDefaultParamMatcher.checkCustomDateType(
               typeMatcher.avroScalaTypes.date)
+          case TimeMillis =>
+            CustomDefaultParamMatcher.checkCustomTimeMillisType(
+              typeMatcher.avroScalaTypes.timeMillis
+            )
         }
       case Type.LONG    =>
         LogicalType.foldLogicalTypes[Tree](

--- a/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultValueMatcher.scala
@@ -45,6 +45,10 @@ object DefaultValueMatcher {
               CustomDefaultValueMatcher.checkCustomDateType(
                 node.longValue(),
                 typeMatcher.avroScalaTypes.date)
+            case TimeMillis =>
+              CustomDefaultValueMatcher.checkCustomTimeMillisType(
+                node.longValue(),
+                typeMatcher.avroScalaTypes.timeMillis)
           }
         case Schema.Type.FLOAT => LIT(node.doubleValue().asInstanceOf[Float])
         case Schema.Type.LONG =>

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -55,6 +55,7 @@ class TypeMatcher(
             schema = schema,
             default = CustomTypeMatcher.checkCustomNumberType(avroScalaTypes.int)) {
             case Date => CustomTypeMatcher.checkCustomDateType(avroScalaTypes.date)
+            case TimeMillis => CustomTypeMatcher.checkCustomTimeMillisType(avroScalaTypes.timeMillis)
           }
         case Schema.Type.NULL     => NullClass
         case Schema.Type.STRING   =>

--- a/avrohugger-core/src/main/scala/matchers/custom/CustomDefaultParamMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/custom/CustomDefaultParamMatcher.scala
@@ -52,4 +52,10 @@ object CustomDefaultParamMatcher {
         }                
     }
   }
+
+  def checkCustomTimeMillisType(timeMillisType: AvroScalaTimeMillisType) =
+    timeMillisType match {
+      case JavaSqlTime => NEW(REF("java.sql.Time"), LIT(0L))
+      case JavaTimeLocalTime  => REF("java.time.LocalTime.now")
+    }
 }

--- a/avrohugger-core/src/main/scala/matchers/custom/CustomDefaultValueMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/custom/CustomDefaultValueMatcher.scala
@@ -20,4 +20,9 @@ object CustomDefaultValueMatcher {
       case JavaTimeInstant   => REF("java.time.Instant.ofEpochMilli") APPLY LIT(value)
     }
 
+  def checkCustomTimeMillisType(value: Long, timeMillisType: AvroScalaTimeMillisType) =
+    timeMillisType match {
+      case JavaSqlTime => NEW("java.sql.Time", LIT(value))
+      case JavaTimeLocalTime => REF("java.time.LocalTime.ofNanoOfDay").APPLY(LIT(value).INFIX("*", LIT(1000000L)))
+    }
 }

--- a/avrohugger-core/src/main/scala/matchers/custom/CustomTypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/custom/CustomTypeMatcher.scala
@@ -48,6 +48,11 @@ object CustomTypeMatcher {
     case JavaTimeInstant  => RootClass.newClass(nme.createNameType("java.time.Instant"))
   }
 
+  def checkCustomTimeMillisType(timeType: AvroScalaTimeMillisType) = timeType match {
+    case JavaSqlTime => RootClass.newClass(nme.createNameType("java.sql.Time"))
+    case JavaTimeLocalTime => RootClass.newClass(nme.createNameType("java.time.LocalTime"))
+  }
+
   def checkCustomDecimalType(decimalType: AvroScalaDecimalType, schema: Schema) =
       LogicalType.foldLogicalTypes(
         schema = schema,

--- a/avrohugger-core/src/main/scala/types/AvroScalaTypes.scala
+++ b/avrohugger-core/src/main/scala/types/AvroScalaTypes.scala
@@ -23,6 +23,7 @@ case class AvroScalaTypes(
   decimal:  AvroScalaDecimalType  = ScalaBigDecimal(None),
   date:     AvroScalaDateType     = JavaTimeLocalDate,
   timestampMillis: AvroScalaTimestampMillisType = JavaTimeInstant,
+  timeMillis: AvroScalaTimeMillisType = JavaTimeLocalTime,
   uuid:     AvroUuidType          = JavaUuid
 )
 

--- a/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala
+++ b/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala
@@ -18,10 +18,15 @@ case object JavaTimeInstant extends AvroScalaTimestampMillisType
 sealed trait AvroUuidType extends Product with Serializable
 case object JavaUuid extends AvroUuidType
 
+sealed trait AvroScalaTimeMillisType extends Product with Serializable
+case object JavaSqlTime extends AvroScalaTimeMillisType
+case object JavaTimeLocalTime extends AvroScalaTimeMillisType
+
 sealed abstract class LogicalType(name: String)
 case class Decimal(precision: Int, scale: Int) extends LogicalType("decimal")
 case object Date extends LogicalType("date")
 case object TimestampMillis extends LogicalType("timestamp-millis")
+case object TimeMillis extends LogicalType("time-millis")
 case object UUID extends LogicalType("uuid")
 
 object LogicalType {
@@ -30,6 +35,7 @@ object LogicalType {
     case d: org.apache.avro.LogicalTypes.Decimal => Some(Decimal(d.getPrecision, d.getScale))
     case _: org.apache.avro.LogicalTypes.Date => Some(Date)
     case _: org.apache.avro.LogicalTypes.TimestampMillis => Some(TimestampMillis)
+    case _: org.apache.avro.LogicalTypes.TimeMillis => Some(TimeMillis)
     case _ if logicalType.getName == "uuid" => Some(UUID)
     case _ => None
   }

--- a/avrohugger-core/src/test/avro/logical.avdl
+++ b/avrohugger-core/src/test/avro/logical.avdl
@@ -8,6 +8,7 @@ protocol LogicalIDL {
     timestamp_ms ts = 1526573732000; //ms from the unix epoch
     date dt = 600; //days from the unix epock, no time precission
     decimal(20, 2) decBig = "\u000C\u006C";
+    time_ms tm = 43200000;
   }
 
 }

--- a/avrohugger-core/src/test/avro/logical.avpr
+++ b/avrohugger-core/src/test/avro/logical.avpr
@@ -50,6 +50,13 @@
           "logicalType": "decimal",
           "precision": 20,
           "scale": 12
+        },
+        {
+          "name": "time",
+          "type": {
+            "type": "int",
+            "logicalType": "time-millis"
+          }
         }
       ]
     }

--- a/avrohugger-core/src/test/avro/logical.avsc
+++ b/avrohugger-core/src/test/avro/logical.avsc
@@ -52,6 +52,13 @@
         "precision": 20,
         "scale": 12
       }
+    },
+    {
+      "name": "tm",
+      "type": {
+        "type": "int",
+        "logicalType": "time-millis"
+      }
     }
   ]
 }

--- a/avrohugger-core/src/test/avro/logicalsql.avsc
+++ b/avrohugger-core/src/test/avro/logicalsql.avsc
@@ -34,6 +34,13 @@
         "precision": 20,
         "scale": 12
       }
+    },
+    {
+      "name": "tm",
+      "type": {
+        "type": "int",
+        "logicalType": "time-millis"
+      }
     }
   ]
 }

--- a/avrohugger-core/src/test/expected/specific/example/logical/LogicalSql.scala
+++ b/avrohugger-core/src/test/expected/specific/example/logical/LogicalSql.scala
@@ -3,8 +3,8 @@ package example.logical
 
 import scala.annotation.switch
 
-final case class LogicalSql(var data: BigDecimal, var ts: java.sql.Timestamp, var dt: java.sql.Date, var dataBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(scala.math.BigDecimal(0), new java.sql.Timestamp(0L), new java.sql.Date(0L), scala.math.BigDecimal(0))
+final case class LogicalSql(var data: BigDecimal, var ts: java.sql.Timestamp, var dt: java.sql.Date, var dataBig: BigDecimal, var tm: java.sql.Time) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(scala.math.BigDecimal(0), new java.sql.Timestamp(0L), new java.sql.Date(0L), scala.math.BigDecimal(0), new java.sql.Time(0L))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
@@ -28,6 +28,9 @@ final case class LogicalSql(var data: BigDecimal, var ts: java.sql.Timestamp, va
         val scaledValue = dataBig.setScale(scale)
         val bigDecimal = scaledValue.bigDecimal
         LogicalSql.decimalConversion.toBytes(bigDecimal, schema, decimalType)
+      }.asInstanceOf[AnyRef]
+      case 4 => {
+        tm.getTime()
       }.asInstanceOf[AnyRef]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
@@ -66,6 +69,13 @@ final case class LogicalSql(var data: BigDecimal, var ts: java.sql.Timestamp, va
           }
         }
       }.asInstanceOf[BigDecimal]
+      case 4 => this.tm = {
+        value match {
+          case (i: Integer) => {
+            new java.sql.Time(i.toLong)
+          }
+        }
+      }.asInstanceOf[java.sql.Time]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -74,6 +84,6 @@ final case class LogicalSql(var data: BigDecimal, var ts: java.sql.Timestamp, va
 }
 
 object LogicalSql {
-  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"LogicalSql\",\"namespace\":\"example.logical\",\"fields\":[{\"name\":\"data\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2}},{\"name\":\"ts\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"dt\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},{\"name\":\"dataBig\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12}}]}")
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"LogicalSql\",\"namespace\":\"example.logical\",\"fields\":[{\"name\":\"data\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2}},{\"name\":\"ts\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"dt\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},{\"name\":\"dataBig\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12}},{\"name\":\"tm\",\"type\":{\"type\":\"int\",\"logicalType\":\"time-millis\"}}]}")
   val decimalConversion = new org.apache.avro.Conversions.DecimalConversion
 }

--- a/avrohugger-core/src/test/expected/specific/example/logical/proto/Logical.scala
+++ b/avrohugger-core/src/test/expected/specific/example/logical/proto/Logical.scala
@@ -3,8 +3,8 @@ package example.logical.proto
 
 import scala.annotation.switch
 
-final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var decBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
+final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var decBig: BigDecimal, var time: java.time.LocalTime) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0), java.time.LocalTime.now)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
@@ -31,6 +31,9 @@ final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt:
         val scaledValue = decBig.setScale(scale)
         val bigDecimal = scaledValue.bigDecimal
         Logical.decimalConversion.toBytes(bigDecimal, schema, decimalType)
+      }.asInstanceOf[AnyRef]
+      case 5 => {
+        time.get(java.time.temporal.ChronoField.MILLI_OF_DAY)
       }.asInstanceOf[AnyRef]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
@@ -76,6 +79,13 @@ final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt:
           }
         }
       }.asInstanceOf[BigDecimal]
+      case 5 => this.time = {
+        value match {
+          case (i: Integer) => {
+            java.time.LocalTime.ofNanoOfDay(i * 1000000L)
+          }
+        }
+      }.asInstanceOf[java.time.LocalTime]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -84,6 +94,6 @@ final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt:
 }
 
 object Logical {
-  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Logical\",\"namespace\":\"example.logical.proto\",\"fields\":[{\"name\":\"dec\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2},\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2},{\"name\":\"ts\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"dt\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},{\"name\":\"uuid\",\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}},{\"name\":\"decBig\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12},\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12}]}")
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Logical\",\"namespace\":\"example.logical.proto\",\"fields\":[{\"name\":\"dec\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2},\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2},{\"name\":\"ts\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"dt\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},{\"name\":\"uuid\",\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}},{\"name\":\"decBig\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12},\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12},{\"name\":\"time\",\"type\":{\"type\":\"int\",\"logicalType\":\"time-millis\"}}]}")
   val decimalConversion = new org.apache.avro.Conversions.DecimalConversion
 }

--- a/avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSc.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSc.scala
@@ -3,4 +3,4 @@ package example.logical
 
 import shapeless.tag.@@
 
-final case class LogicalSc(data: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], fxField: fxType, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))])
+final case class LogicalSc(data: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], fxField: fxType, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))], tm: java.time.LocalTime)

--- a/avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSql.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSql.scala
@@ -3,4 +3,4 @@ package example.logical
 
 import shapeless.tag.@@
 
-final case class LogicalSql(data: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], ts: java.sql.Timestamp, dt: java.sql.Date, dataBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))])
+final case class LogicalSql(data: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], ts: java.sql.Timestamp, dt: java.sql.Date, dataBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))], tm: java.sql.Time)

--- a/avrohugger-core/src/test/expected/standard-tagged/example/logical/proto/Logical.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/logical/proto/Logical.scala
@@ -3,4 +3,4 @@ package example.logical.proto
 
 import shapeless.tag.@@
 
-final case class Logical(dec: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, decBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))])
+final case class Logical(dec: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, decBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))], time: java.time.LocalTime)

--- a/avrohugger-core/src/test/expected/standard/example/logical/LogicalSc.scala
+++ b/avrohugger-core/src/test/expected/standard/example/logical/LogicalSc.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.logical
 
-final case class LogicalSc(data: BigDecimal, fxField: fxType, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: BigDecimal)
+final case class LogicalSc(data: BigDecimal, fxField: fxType, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: BigDecimal, tm: java.time.LocalTime)

--- a/avrohugger-core/src/test/expected/standard/example/logical/LogicalSql.scala
+++ b/avrohugger-core/src/test/expected/standard/example/logical/LogicalSql.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.logical
 
-final case class LogicalSql(data: BigDecimal, ts: java.sql.Timestamp, dt: java.sql.Date, dataBig: BigDecimal)
+final case class LogicalSql(data: BigDecimal, ts: java.sql.Timestamp, dt: java.sql.Date, dataBig: BigDecimal, tm: java.sql.Time)

--- a/avrohugger-core/src/test/expected/standard/example/logical/proto/Logical.scala
+++ b/avrohugger-core/src/test/expected/standard/example/logical/proto/Logical.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.logical.proto
 
-final case class Logical(dec: BigDecimal, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, decBig: BigDecimal)
+final case class Logical(dec: BigDecimal, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, decBig: BigDecimal, time: java.time.LocalTime)

--- a/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
@@ -44,7 +44,7 @@ class SpecificFileToFileSpec extends Specification {
       correctly generate logical types from schema $e24
       correctly generate logical types from protocol $e25
    
-      correctly generate logical types with custom date and timestamp types $e27
+      correctly generate logical types with custom date, timestamp and time types $e27
       correctly generate a protocol with special strings $e28
       correcty generate a simple case class with a wildcarded custom namespace $e29
   """
@@ -350,7 +350,7 @@ class SpecificFileToFileSpec extends Specification {
 
   def e27 = {
     val infile = new java.io.File("avrohugger-core/src/test/avro/logicalsql.avsc")
-    val avroScalaCustomTypes = SpecificRecord.defaultTypes.copy(date = JavaSqlDate, timestampMillis = JavaSqlTimestamp)
+    val avroScalaCustomTypes = SpecificRecord.defaultTypes.copy(date = JavaSqlDate, timestampMillis = JavaSqlTimestamp, timeMillis = JavaSqlTime)
     val gen = new Generator(SpecificRecord, avroScalaCustomTypes = Some(avroScalaCustomTypes))
     val outDir = gen.defaultOutputDir + "/specific/"
     gen.fileToFile(infile, outDir)

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -49,10 +49,10 @@ class StandardFileToFileSpec extends Specification {
     correctly generate a protocol with no ADT when asked $e27
     correctly generate logical types from schema $e28
     correctly generate logical types from protocol $e29
-    correctly generate logical types with custom date and timestamp types $e31
+    correctly generate logical types with custom date, timestamp and time types $e31
     correctly generate logical types from schema with tagged decimals $e32
     correctly generate logical types from protocol tagged decimals $e33
-    correctly generate logical types with custom date and timestamp types tagged decimals $e35
+    correctly generate logical types with custom date, timestamp and time types tagged decimals $e35
     correctly generate optional logical types from IDL tagged decimals $e36
     correctly generate an either containing logical types from IDL tagged decimals $e37
     correctly generate a coproduct containing logical types from IDL tagged decimals $e38
@@ -466,7 +466,7 @@ class StandardFileToFileSpec extends Specification {
   
   def e31 = {
     val infile = new java.io.File("avrohugger-core/src/test/avro/logicalsql.avsc")
-    val avroScalaCustomTypes = Standard.defaultTypes.copy(date = JavaSqlDate, timestampMillis = JavaSqlTimestamp)
+    val avroScalaCustomTypes = Standard.defaultTypes.copy(date = JavaSqlDate, timestampMillis = JavaSqlTimestamp, timeMillis = JavaSqlTime)
     val gen = new Generator(Standard, avroScalaCustomTypes = Some(avroScalaCustomTypes))
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(infile, outDir)
@@ -514,7 +514,8 @@ class StandardFileToFileSpec extends Specification {
 
   def e35 = {
     val infile = new java.io.File("avrohugger-core/src/test/avro/logicalsql.avsc")
-    val avroScalaCustomTypes = Standard.defaultTypes.copy(date = JavaSqlDate, timestampMillis = JavaSqlTimestamp, decimal = ScalaBigDecimalWithPrecision(None))
+    val avroScalaCustomTypes = Standard.defaultTypes.copy(date = JavaSqlDate, timestampMillis = JavaSqlTimestamp,
+      decimal = ScalaBigDecimalWithPrecision(None), timeMillis = JavaSqlTime)
     val gen = new Generator(Standard, avroScalaCustomTypes = Some(avroScalaCustomTypes))
     val outDir = gen.defaultOutputDir + "/standard-tagged/"
     gen.fileToFile(infile, outDir)


### PR DESCRIPTION
I've noticed that only `timestamp-millis` and a couple of other logical types are supported. This PR adds support for another one - `time-millis` with customizable type mapping to `java.time.LocalTime` or `java.sql.Time`