### PR TITLE
Added unit to the set of reserved keywords

### DIFF
--- a/avrohugger-core/src/main/scala/format/FieldRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/FieldRenamer.scala
@@ -5,7 +5,7 @@ object FieldRenamer {
   // Reserved words from https://www.scala-lang.org/files/archive/spec/2.13/01-lexical-syntax.html#identifiers
   private val RESERVED_WORDS: Set[String] = Set("abstract", "case", "catch", "class", "def", "do", "else", "extends", "final", "finally",
     "for", "forSome", "if", "implicit", "lazy", "macro", "match", "new", "object", "override", "package", "private", "protected", "return",
-    "sealed", "super", "this", "throw", "trait", "try", "type", "val", "var", "while", "with", "yield")
+    "sealed", "super", "this", "throw", "trait", "try", "type", "unit", "val", "var", "while", "with", "yield")
 
   private def backtick(variable: String): String = s"`$variable`"
 

--- a/avrohugger-core/src/test/avro/special_names.avdl
+++ b/avrohugger-core/src/test/avro/special_names.avdl
@@ -4,5 +4,6 @@ protocol SpecialNames {
   record Names {
     string `protected`;
     string `ends_with_`;
+    string `unit`;
   }
 }

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Names.scala
@@ -7,10 +7,10 @@ import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
 import example.idl.{Names => JNames}
 
-final case class Names(`protected`: String, `ends_with_`: String) extends AvroSerializeable {
+final case class Names(`protected`: String, `ends_with_`: String, `unit`: String) extends AvroSerializeable {
   type J = JNames
   override def toAvro: JNames = {
-    new JNames(`protected`, `ends_with_`)
+    new JNames(`protected`, `ends_with_`, `unit`)
   }
 }
 
@@ -22,7 +22,7 @@ object Names {
     override val avroClass: Class[JNames] = classOf[JNames]
     override val schema: Schema = JNames.getClassSchema()
     override val fromAvro: (JNames) => Names = {
-      (j: JNames) => Names(j.getProtected$.toString, j.getEndsWith.toString)
+      (j: JNames) => Names(j.getProtected$.toString, j.getEndsWith.toString, j.getUnit.toString)
     }
   }
 }

--- a/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Names.scala
@@ -3,8 +3,8 @@ package example.idl
 
 import scala.annotation.switch
 
-final case class Names(var `protected`: String, var `ends_with_`: String) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this("", "")
+final case class Names(var `protected`: String, var `ends_with_`: String, var `unit`: String) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this("", "", "")
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
@@ -12,6 +12,9 @@ final case class Names(var `protected`: String, var `ends_with_`: String) extend
       }.asInstanceOf[AnyRef]
       case 1 => {
         `ends_with_`
+      }.asInstanceOf[AnyRef]
+      case 2 => {
+        `unit`
       }.asInstanceOf[AnyRef]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
@@ -24,6 +27,9 @@ final case class Names(var `protected`: String, var `ends_with_`: String) extend
       case 1 => this.`ends_with_` = {
         value.toString
       }.asInstanceOf[String]
+      case 2 => this.`unit` = {
+        value.toString
+      }.asInstanceOf[String]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -32,5 +38,5 @@ final case class Names(var `protected`: String, var `ends_with_`: String) extend
 }
 
 object Names {
-  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Names\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"protected\",\"type\":\"string\"},{\"name\":\"ends_with_\",\"type\":\"string\"}]}")
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Names\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"protected\",\"type\":\"string\"},{\"name\":\"ends_with_\",\"type\":\"string\"},{\"name\":\"unit\",\"type\":\"string\"}]}")
 }

--- a/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Names.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-final case class Names(`protected`: String, `ends_with_`: String)
+final case class Names(`protected`: String, `ends_with_`: String, `unit`: String)


### PR DESCRIPTION
Now unit is part of the set of the reserved keywords and will be escaped with backticks in case it is used as a property in an avro schema.

Fixes https://github.com/julianpeeters/avrohugger/issues/163