### PR TITLE
fix: https://github.com/julianpeeters/sbt-avrohugger/issues/94

### DIFF
--- a/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
@@ -222,7 +222,8 @@ trait SourceFormat {
     }
     val contents = compilationUnit.codeString.getBytes()
     try { // delete old and/or create new
-      Files.deleteIfExists(path)
+      Files.deleteIfExists(path) // delete file if exists
+      Files.createDirectories(path.getParent) // create all parent folders
       Files.write(path, contents, StandardOpenOption.CREATE)
       ()
     }


### PR DESCRIPTION
Files were generated into not-existing folder, added call to create all missing parent folders.