### PR TITLE
1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10, 2.12.17]
+        scala: [2.13.11, 2.12.18]
         java: [zulu@1.8, zulu@1.11, zulu@1.17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ runtime, Java classes provided separately (see [Scavro Plugin](https://github.co
 ##### Supports generating case classes with arbitrary fields of the following datatypes:
 
 |Avro|`Standard`|`SpecificRecord`|Notes|
-|----------|---------|----------|---------|---------|
+|----------|---------|----------|---------|
 |INT|Int|Int| See [Logical Types: `date`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
 |LONG|Long|Long| See [Logical Types: `timestamp-millis`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
 |FLOAT|Float|Float||
@@ -122,7 +122,7 @@ _Note:_ Currently [Treehugger](http://eed3si9n.com/treehugger/comments.html#Scal
 
 ##### Get the dependency with:
 
-    "com.julianpeeters" %% "avrohugger-core" % "1.4.0"
+    "com.julianpeeters" %% "avrohugger-core" % "1.5.0"
 
 
 ##### Description:
@@ -202,7 +202,7 @@ namespace rewritten. Multiple conflicting wildcards are not permitted.
 
 ##### Get the dependency with:
 
-    "com.julianpeeters" %% "avrohugger-filesorter" % "1.4.0"
+    "com.julianpeeters" %% "avrohugger-filesorter" % "1.5.0"
     
 
 ##### Description:
@@ -222,22 +222,22 @@ To ensure dependent schemas are compiled in the proper order (thus avoiding `org
 #### `avrohugger-tools`
 
 
-  Download the avrohugger-tools jar for Scala [2.12](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.12/1.4.0/avrohugger-tools_2.12-1.4.0-assembly.jar), or Scala [2.13](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.13/1.4.0/avrohugger-tools_2.13-1.4.0-assembly.jar) (>30MB!) and use it like the avro-tools jar `Usage: [-string] (schema|protocol|datafile) input... outputdir`:
+  Download the avrohugger-tools jar for Scala [2.12](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.12/1.5.0/avrohugger-tools_2.12-1.5.0-assembly.jar), or Scala [2.13](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.13/1.5.0/avrohugger-tools_2.13-1.5.0-assembly.jar) (>30MB!) and use it like the avro-tools jar `Usage: [-string] (schema|protocol|datafile) input... outputdir`:
 
 
 * `generate` generates Scala case class definitions:
 
-`java -jar /path/to/avrohugger-tools_2.12-1.4.0-assembly.jar generate schema user.avsc . `
+`java -jar /path/to/avrohugger-tools_2.12-1.5.0-assembly.jar generate schema user.avsc . `
 
 
 * `generate-specific` generates definitions that extend Avro's `SpecificRecordBase`:
 
-`java -jar /path/to/avrohugger-tools_2.12-1.4.0-assembly.jar generate-specific schema user.avsc . `
+`java -jar /path/to/avrohugger-tools_2.12-1.5.0-assembly.jar generate-specific schema user.avsc . `
 
 
 * `generate-scavro` (@deprecated since avrohugger v1.5.0) generates definitions that extend Scavro's `AvroSerializable`:
 
-`java -jar /path/to/avrohugger-tools_2.12-1.4.0-assembly.jar generate-scavro schema user.avsc . `
+`java -jar /path/to/avrohugger-tools_2.12-1.5.0-assembly.jar generate-scavro schema user.avsc . `
 
 
 ## Warnings

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 
 [![Scala CI](https://github.com/julianpeeters/avrohugger/workflows/Scala%20CI/badge.svg)](https://github.com/julianpeeters/avrohugger/actions?query=workflow%3A%22Scala+CI%22)
-[![Join the chat at https://gitter.im/julianpeeters/avrohugger](https://badges.gitter.im/julianpeeters/avrohugger.svg)](https://gitter.im/julianpeeters/avrohugger?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.julianpeeters/avrohugger-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.julianpeeters/avrohugger-core_2.12)
 
 **Schema-to-case-class code generation for working with Avro in Scala.**
@@ -22,7 +21,7 @@
 Table of contents
 =================
 
-  * [Supported Formats: `Standard`, `SpecificRecord`, `Scavro`](#generates-scala-case-classes-in-various-formats)
+  * [Supported Formats: `Standard`, `SpecificRecord`](#generates-scala-case-classes-in-various-formats)
   * [Supported Datatypes](#supports-generating-case-classes-with-arbitrary-fields-of-the-following-datatypes)
   * [Logical Types Support](#logical-types-support)
   * [Protocol Support](#protocol-support)
@@ -52,33 +51,33 @@ API](https://avro.apache.org/docs/1.11.1/getting-started-java/#serializing-and-d
 therefore have mutable `var` fields (for use with the Avro Specific API -
 Scalding, Spark, Avro, etc.).
 
-* `Scavro` Case classes with immutable fields, intended to wrap Java generated
+* `Scavro` (@deprecated since avrohugger v1.5.0) Case classes with immutable fields, intended to wrap Java generated
 Avro classes (for use with the [Scavro](https://github.com/oedura/scavro#scavro-reader-and-writer)
 runtime, Java classes provided separately (see [Scavro Plugin](https://github.com/oedura/scavro#scavro-plugin) or [sbt-avro](https://github.com/sbt/sbt-avro))).
 
 ##### Supports generating case classes with arbitrary fields of the following datatypes:
 
-|Avro|`Standard`|`SpecificRecord`|`Scavro`|Notes|
+|Avro|`Standard`|`SpecificRecord`|Notes|
 |----------|---------|----------|---------|---------|
-|INT|Int|Int|Int| See [Logical Types: `date`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
-|LONG|Long|Long|Long| See [Logical Types: `timestamp-millis`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
-|FLOAT|Float|Float|Float||
-|DOUBLE|Double|Double|Double||
-|STRING|String|String|String||
-|BOOLEAN|Boolean|Boolean|Boolean||
-|NULL|Null|Null|Null||
-|MAP|Map|Map|Map||
-|ENUM|scala.Enumeration<br>Scala case object<br>Java Enum<br>EnumAsScalaString|Java Enum<br>EnumAsScalaString|scala.Enumeration<br>Scala case object<br>Java Enum<br>EnumAsScalaString| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|BYTES|Array[Byte]<br>BigDecimal|Array[Byte]<br>BigDecimal|Array[Byte]|See [Logical Types: `decimal`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
-|FIXED|case class<br>case class + schema|case class extending `SpecificFixed`|//TODO|See [Logical Types: `decimal`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
-|ARRAY|Seq<br>List<br>Array<br>Vector|Seq<br>List<br>Array<br>Vector|Array<br>Seq<br>List<br>Vector| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|UNION|Option<br>Either<br>Shapeless Coproduct|Option<br>Either<br>Shapeless Coproduct|Option| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|RECORD|case class<br>case class + schema|case class extending `SpecificRecordBase`|case class extending `AvroSerializeable`| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|PROTOCOL|_No Type_<br>Scala ADT|RPC trait<br>Scala ADT|_No Type_<br>Scala ADT| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|Date|java.time.LocalDate<br>java.sql.Date|java.time.LocalDate<br>java.sql.Date|Not yet supported| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|TimestampMillis|java.time.Instant<br>java.sql.Timestamp|java.time.Instant<br>java.sql.Timestamp|Not yet supported|  See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|UUID|java.util.UUID|java.util.UUID|Not yet supported|  See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
-|Decimal|BigDecimal|BigDecimal|Not yet supported|  See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|INT|Int|Int| See [Logical Types: `date`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
+|LONG|Long|Long| See [Logical Types: `timestamp-millis`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
+|FLOAT|Float|Float||
+|DOUBLE|Double|Double||
+|STRING|String|String||
+|BOOLEAN|Boolean|Boolean||
+|NULL|Null|Null||
+|MAP|Map|Map||
+|ENUM|scala.Enumeration<br>Scala case object<br>Java Enum<br>EnumAsScalaString|Java Enum<br>EnumAsScalaString| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|BYTES|Array[Byte]<br>BigDecimal|Array[Byte]<br>BigDecimal| See [Logical Types: `decimal`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
+|FIXED|case class<br>case class + schema|case class extending `SpecificFixed`| See [Logical Types: `decimal`](https://github.com/julianpeeters/avrohugger#logical-types-support)|
+|ARRAY|Seq<br>List<br>Array<br>Vector|Seq<br>List<br>Array<br>Vector| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|UNION|Option<br>Either<br>Shapeless Coproduct|Option<br>Either<br>Shapeless Coproduct| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|RECORD|case class<br>case class + schema|case class extending `SpecificRecordBase`| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|PROTOCOL|_No Type_<br>Scala ADT|RPC trait<br>Scala ADT| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|Date|java.time.LocalDate<br>java.sql.Date|java.time.LocalDate<br>java.sql.Date| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|TimestampMillis|java.time.Instant<br>java.sql.Timestamp|java.time.Instant<br>java.sql.Timestamp| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|UUID|java.util.UUID|java.util.UUID| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
+|Decimal|BigDecimal|BigDecimal| See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)|
 
 ##### Logical Types Support:
 
@@ -87,7 +86,7 @@ _NOTE: Currently logical types are only supported for `Standard` and `SpecificRe
 * `date`: Annotates Avro `int` schemas to generate `java.time.LocalDate` or `java.sql.Date` (See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)). Examples: [avdl](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avdl#L9), [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L22-L27).
 * `decimal`: Annotates Avro `bytes` and `fixed` schemas to generate `BigDecimal`. Examples: [avdl](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avdl#L6), [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L6-L14).
 * `timestamp-millis`: Annotates Avro `long` schemas to genarate `java.time.Instant` or `java.sql.Timestamp` (See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)). Examples: [avdl](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avdl#L8), [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L15-L21).
-* `uuid`: Annotates Avro `string` schemas (but not idls as of avro 1.8.2) to generate `java.util.UUID` (See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)). Example: [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L29-L35).
+* `uuid`: Annotates Avro `string` schemas and idls to generate `java.util.UUID` (See [Customizable Type Mapping](https://github.com/julianpeeters/avrohugger#customizable-type-mapping)). Example: [avsc](https://github.com/julianpeeters/sbt-avrohugger/blob/master/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/logical.avsc#L29-L35).
 * `time-millis`: Annotates Avro `int` schemas to genarate `java.time.LocalTime` or `java.sql.Time`
 
 ##### Protocol Support:
@@ -191,13 +190,6 @@ namespace map (please see warnings below):
 
     val generator = new Generator(SpecificRecord, avroScalaCustomNamespace = Map("oldnamespace"->"newnamespace"))
 
-
-_Scavro_: by default, a "model" package is appended to the namespace to create a
- Scala namespace that does not conflict with Scavro's generated Java. To
- override, either customize each package namespace separately (preempting the
- use of the default package name), or override the package name like so:
-
-    val generator = new Generator(SpecificRecord, avroScalaCustomNamespace = Map("SCAVRO_DEFAULT_PACKAGE$"->"scavro"))
     
 Wildcarding the beginning of a namespace is permitted, place a single asterisk after the prefix that you want to map and any matching schema will have its 
 namespace rewritten. Multiple conflicting wildcards are not permitted.
@@ -243,7 +235,7 @@ To ensure dependent schemas are compiled in the proper order (thus avoiding `org
 `java -jar /path/to/avrohugger-tools_2.12-1.4.0-assembly.jar generate-specific schema user.avsc . `
 
 
-* `generate-scavro` generates definitions that extend Scavro's `AvroSerializable`:
+* `generate-scavro` (@deprecated since avrohugger v1.5.0) generates definitions that extend Scavro's `AvroSerializable`:
 
 `java -jar /path/to/avrohugger-tools_2.12-1.4.0-assembly.jar generate-scavro schema user.avsc . `
 
@@ -259,28 +251,7 @@ mutable (`var`) in order to be compatible with the SpecificRecord API. _Note:_
 If your framework allows `GenericRecord`, [avro4s](https://github.com/sksamuel/avro4s)
 provides a type class that converts to and from immutable case classes cleanly.
 
-3) When the input is a case class definition `String`, import statements are
-not supported, please use fully qualified type names if using records/classes
-from multiple namespaces.
-
-4) By default, a schema's namespace is used as a package name. In the case of
-the Scavro output format, the default is the namespace with `model` appended.
-
-5) While Scavro format uses custom namespaces in a way that leaves it
-unaffected, most formats fail on schemas with records within unions
-(see [avro forum](see http://apache-avro.679487.n3.nabble.com/Deserialize-with-different-schema-td4032782.html)).
-
-6) `SpecificRecord` requires that `enum` be represented as `JavaEnum`
-
-
-## Best Practices
-
-1) Avoid recursive schemas since they can cause compatibility issues if trying
-to flow data into a system that doesn't support them (e.g., Hive).
-
-2) Use namespaces to ensure compatibility when importing into Java/Scala.
-
-3) Use default field values in case of future schema evolution ([further reading](https://github.com/julianpeeters/avrohugger/issues/23)).
+3) `SpecificRecord` requires that `enum` be represented as `JavaEnum`
 
 
 ## Testing
@@ -302,7 +273,7 @@ Contributors:
 
 | | | |
 | :---         |     :---      |          :--- |
-| [Marius Soutier](https://github.com/mariussoutier) </br> [Brian London](https://github.com/BrianLondon) </br> [alancnet](https://github.com/alancnet) </br> [Matt Coffin](https://github.com/mcoffin) </br> [Ryan Koval](http://github.ryankoval.com) </br> [Simonas Gelazevicius](https://github.com/simsasg) </br> [Paul Snively](https://github.com/PaulAtBanno) </br> [Marco Stefani](https://github.com/inafets) </br> [Andrew Gustafson](https://github.com/agustafson) </br> [Kostya Golikov](https://github.com/lazyval) </br> [Plínio Pantaleão](https://github.com/plinioj) </br> [Sietse de Kaper](https://github.com/targeter) </br> [Martin Mauch](https://github.com/nightscape) </br> [Konstantin](https://github.com/tyger) </br> [Adam Drakeford](https://github.com/dr4ke616) </br> [Carlos Silva](https://github.com/alchimystic) </br> [ismailBenammar](https://github.com/ismailBenammar) | [Paul Pearcy](https://github.com/ppearcy) </br> [Matt Allen](https://github.com/Matt343) </br> [C-zito](https://github.com/C-Zito) </br> [Tim Chan](https://github.com/timchan-lumoslabs) </br> [Saket](https://github.com/skate056) </br> [Daniel Davis](https://github.com/wabu) </br> [Zach Cox](https://github.com/zcox) </br> [Diego E. Alonso Blas](https://github.com/diesalbla) </br> [Fede Fernández](https://github.com/fedefernandez) </br> [Rob Landers](https://github.com/withinboredom) </br> [Simon Petty](https://github.com/simonpetty) </br> [Andreas Drobisch](https://github.com/adrobisch) </br> [natefitzgerald](https://github.com/natefitzgerald) </br> [Timo Schmid](https://github.com/timo-schmid) </br> [mcenkar](https://github.com/mcenkar) </br> [Luca Tronchin](https://github.com/ltronky) | [Stefano Galarraga](https://github.com/galarragas) </br> [Lars Albertsson](https://github.com/lallea) </br> [Eugene Platonov](https://github.com/jozic) </br> [Jerome Wacongne](https://github.com/ch4mpy) </br> [Jon Morra](https://github.com/jon-morra-zefr) </br> [Raúl Raja Martínez](https://github.com/raulraja) </br> [Kaur Matas](https://github.com/kmatasflp) </br> [Chris Albright](https://github.com/chrisalbright) </br> [Francisco Díaz](https://github.com/franciscodr) </br> [Bobby Rauchenberg](https://github.com/bobbyrauchenberg) </br> [Leonard Ehrenfried](https://github.com/leonardehrenfried) </br> [François Sarradin](https://github.com/fsarradin) </br> [niqdev](https://github.com/niqdev) </br> [Julien BENOIT](https://github.com/jbenoit2011) </br> [Algimantas Milašius](https://github.com/AlgMi) </br> [Leonard Ehrenfried](https://github.com/leonardehrenfried) </br> [Massimo Siani](https://github.com/massimosiani)| 
+| [Marius Soutier](https://github.com/mariussoutier) </br> [Brian London](https://github.com/BrianLondon) </br> [alancnet](https://github.com/alancnet) </br> [Matt Coffin](https://github.com/mcoffin) </br> [Ryan Koval](http://github.ryankoval.com) </br> [Simonas Gelazevicius](https://github.com/simsasg) </br> [Paul Snively](https://github.com/PaulAtBanno) </br> [Marco Stefani](https://github.com/inafets) </br> [Andrew Gustafson](https://github.com/agustafson) </br> [Kostya Golikov](https://github.com/lazyval) </br> [Plínio Pantaleão](https://github.com/plinioj) </br> [Sietse de Kaper](https://github.com/targeter) </br> [Martin Mauch](https://github.com/nightscape) </br> [Konstantin](https://github.com/tyger) </br> [Adam Drakeford](https://github.com/dr4ke616) </br> [Carlos Silva](https://github.com/alchimystic) </br> [ismail Benammar](https://github.com/ismailBenammar) | [Paul Pearcy](https://github.com/ppearcy) </br> [Matt Allen](https://github.com/Matt343) </br> [C-zito](https://github.com/C-Zito) </br> [Tim Chan](https://github.com/timchan-lumoslabs) </br> [Saket](https://github.com/skate056) </br> [Daniel Davis](https://github.com/wabu) </br> [Zach Cox](https://github.com/zcox) </br> [Diego E. Alonso Blas](https://github.com/diesalbla) </br> [Fede Fernández](https://github.com/fedefernandez) </br> [Rob Landers](https://github.com/withinboredom) </br> [Simon Petty](https://github.com/simonpetty) </br> [Andreas Drobisch](https://github.com/adrobisch) </br> [natefitzgerald](https://github.com/natefitzgerald) </br> [Timo Schmid](https://github.com/timo-schmid) </br> [mcenkar](https://github.com/mcenkar) </br> [Luca Tronchin](https://github.com/ltronky) </br> [LydiaSkuse](https://github.com/LydiaSkuse) | [Stefano Galarraga](https://github.com/galarragas) </br> [Lars Albertsson](https://github.com/lallea) </br> [Eugene Platonov](https://github.com/jozic) </br> [Jerome Wacongne](https://github.com/ch4mpy) </br> [Jon Morra](https://github.com/jon-morra-zefr) </br> [Raúl Raja Martínez](https://github.com/raulraja) </br> [Kaur Matas](https://github.com/kmatasflp) </br> [Chris Albright](https://github.com/chrisalbright) </br> [Francisco Díaz](https://github.com/franciscodr) </br> [Bobby Rauchenberg](https://github.com/bobbyrauchenberg) </br> [Leonard Ehrenfried](https://github.com/leonardehrenfried) </br> [François Sarradin](https://github.com/fsarradin) </br> [niqdev](https://github.com/niqdev) </br> [Julien BENOIT](https://github.com/jbenoit2011) </br> [Algimantas Milašius](https://github.com/AlgMi) </br> [Leonard Ehrenfried](https://github.com/leonardehrenfried) </br> [Massimo Siani](https://github.com/massimosiani)| 
 
 
 

--- a/avrohugger-core/src/main/scala/format/Scavro.scala
+++ b/avrohugger-core/src/main/scala/format/Scavro.scala
@@ -29,6 +29,7 @@ object Scavro extends SourceFormat {
   
   val defaultTypes: AvroScalaTypes = AvroScalaTypes.defaults.copy(array = ScalaArray)
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def asCompilationUnits(
     classStore: ClassStore,
     maybeNamespace: Option[String],
@@ -174,6 +175,7 @@ object Scavro extends SourceFormat {
     }
   }
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def compile(
     classStore: ClassStore,
     maybeNamespace: Option[String],

--- a/avrohugger-core/src/main/scala/format/scavro/ScavroImporter.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroImporter.scala
@@ -16,6 +16,7 @@ import scala.jdk.CollectionConverters._
 
 object ScavroImporter extends Importer {
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def asRenamedImportTree(imported: Import) = {
     val packageSym = imported.expr
     val typeNames = imported.selectors.map(s => treeToString(s.name))
@@ -26,6 +27,7 @@ object ScavroImporter extends Importer {
     IMPORT(packageSym, renames)
   }
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def getImports(
     schemaOrProtocol: Either[Schema, Protocol],
     currentNamespace: Option[String],

--- a/avrohugger-core/src/main/scala/format/scavro/ScavroJavaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroJavaTreehugger.scala
@@ -9,6 +9,7 @@ import org.apache.avro.Schema
 
 object ScavroJavaTreehugger extends JavaTreehugger {
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def asJavaCodeString(
     classStore: ClassStore,
     namespace: Option[String],

--- a/avrohugger-core/src/main/scala/format/scavro/ScavroMethodRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroMethodRenamer.scala
@@ -18,6 +18,7 @@ object ScavroMethodRenamer {
     * @param postfix method name postfix, e.g. "" or "Builder".
     * @return the generated method name.
     */
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def generateMethodName(
     schema: Schema,
     field: Field,

--- a/avrohugger-core/src/main/scala/format/scavro/ScavroNamespaceRenamer.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroNamespaceRenamer.scala
@@ -10,6 +10,7 @@ object ScavroNamespaceRenamer {
   // By default, Scavro generates Scala classes in packages that are the same
   // as the Java package with `model` appended.
   // TypeMatcher is here because it holds the custom namespace map
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def renameNamespace(
     maybeNamespace: Option[String],
     schemaOrProtocol: Either[Schema, Protocol],

--- a/avrohugger-core/src/main/scala/format/scavro/ScavroScalaTreehugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/ScavroScalaTreehugger.scala
@@ -20,6 +20,7 @@ object ScavroScalaTreehugger extends ScalaTreehugger {
 
   // SpecificCompiler can't return a tree for Java enums, so return
   // a String here for a consistent api vis a vis *ToFile and *ToStrings
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def asScalaCodeString(
     classStore: ClassStore,
     namespace: Option[String],

--- a/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroProtocolhugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroProtocolhugger.scala
@@ -16,6 +16,7 @@ import treehugger.forest._
 
 object ScavroProtocolhugger extends Protocolhugger {
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def toTrees(
     schemaStore: SchemaStore,
     classStore: ClassStore,

--- a/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroSchemahugger.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/avrohuggers/ScavroSchemahugger.scala
@@ -17,6 +17,7 @@ import definitions._
 
 object ScavroSchemahugger extends Schemahugger{
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def toTrees(
     schemaStore: SchemaStore,
     classStore: ClassStore,

--- a/avrohugger-core/src/main/scala/format/scavro/converters/JavaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/converters/JavaConverter.scala
@@ -16,7 +16,8 @@ class JavaConverter(
   classStore: ClassStore,
   namespace: Option[String],
   typeMatcher: TypeMatcher) {
-  
+
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def checkCustomNumberType(
     numberType: AvroScalaNumberType,
     defaultNumberType: AvroScalaNumberType,
@@ -25,7 +26,8 @@ class JavaConverter(
     if (numberType == defaultNumberType) tree
     else tree DOT nativeType
   }
-  
+
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def checkCustomEnumType(
     schema: Schema,
     enumType: AvroScalaEnumType,
@@ -48,6 +50,7 @@ class JavaConverter(
   // REF("fieldName"), which is wrapped in a pattern match tree (e.g., to sort 
   // None and Some(x) if the field is a union). A Schema is passed in order to 
   // get access to the field's type parameters while the tree is built up.
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def convertToJava(
     schema: Schema,
     tree: Tree,

--- a/avrohugger-core/src/main/scala/format/scavro/converters/ScalaConverter.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/converters/ScalaConverter.scala
@@ -16,7 +16,8 @@ import scala.language.postfixOps
 import scala.jdk.CollectionConverters._
 
 class ScalaConverter(typeMatcher: TypeMatcher) {
-
+  
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def convertFromJava(
     schema: Schema,
     tree: Tree,

--- a/avrohugger-core/src/main/scala/format/scavro/trees/ScavroCaseClassTree.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/trees/ScavroCaseClassTree.scala
@@ -16,6 +16,7 @@ import scala.language.postfixOps
 
 object ScavroCaseClassTree {
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def toCaseClassDef(
     classStore: ClassStore,
     namespace: Option[String],

--- a/avrohugger-core/src/main/scala/format/scavro/trees/ScavroObjectTree.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/trees/ScavroObjectTree.scala
@@ -16,6 +16,7 @@ import scala.jdk.CollectionConverters._
 object ScavroObjectTree {
 
   // for generating enums
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def toScalaEnumDef(
     classStore: ClassStore, 
     schema: Schema,

--- a/avrohugger-core/src/main/scala/format/scavro/trees/ScavroTraitTree.scala
+++ b/avrohugger-core/src/main/scala/format/scavro/trees/ScavroTraitTree.scala
@@ -18,6 +18,7 @@ import scala.jdk.CollectionConverters._
 
 object ScavroTraitTree {
 
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def toADTRootDef(protocol: Protocol, typeMatcher: TypeMatcher) = {
     def isEnum(schema: Schema) = schema.getType == ENUM
     val sealedTraitTree =  TRAITDEF(protocol.getName).withFlags(Flags.SEALED)
@@ -42,7 +43,8 @@ object ScavroTraitTree {
     
     treeWithScalaDoc
   }
-  
+
+  @deprecated("Scavro will no longer be supported", "avrohugger 1.5.0")
   def toCaseObjectEnumDef(schema: Schema,
     maybeBaseTrait: Option[String]): List[Tree] = {
     val adtRootTree: Tree = maybeBaseTrait match {

--- a/avrohugger-core/src/main/scala/input/parsers/StringInputParser.scala
+++ b/avrohugger-core/src/main/scala/input/parsers/StringInputParser.scala
@@ -66,6 +66,7 @@ class StringInputParser {
         }
       }
 
+    @deprecated("Reflective compilation will no longer be supported", "avrohugger 1.5.0")
     def tryCaseClass(
       str: String,
       schemaStore: SchemaStore): List[Either[Schema, Protocol]] = {

--- a/avrohugger-core/src/main/scala/input/reflectivecompilation/PackageSplitter.scala
+++ b/avrohugger-core/src/main/scala/input/reflectivecompilation/PackageSplitter.scala
@@ -6,6 +6,7 @@ import scala.jdk.CollectionConverters._
 
 object PackageSplitter {
 
+  @deprecated("Reflective compilation will no longer be supported", "avrohugger 1.5.0")
   def getCompilationUnits(code: String): List[String] = {
 
     def getCompilationUnits(

--- a/avrohugger-core/src/main/scala/input/reflectivecompilation/schemagen/EnumSchemaGenerator.scala
+++ b/avrohugger-core/src/main/scala/input/reflectivecompilation/schemagen/EnumSchemaGenerator.scala
@@ -15,6 +15,7 @@ import scala.jdk.CollectionConverters._
 
 object EnumSchemaGenerator  {
 
+  @deprecated("Reflective compilation will no longer be supported", "avrohugger 1.5.0")
   def generateSchema(
     className: String, 
     namespace: Option[Name], 

--- a/avrohugger-core/src/main/scala/input/reflectivecompilation/schemagen/FieldSchemaGenerator.scala
+++ b/avrohugger-core/src/main/scala/input/reflectivecompilation/schemagen/FieldSchemaGenerator.scala
@@ -17,7 +17,8 @@ import scala.reflect.runtime.universe._
 import scala.tools.reflect.ToolBox
 
 class FieldSchemaGenerator() {
- 
+
+  @deprecated("Reflective compilation will no longer be supported", "avrohugger 1.5.0")
   def toAvroField(
     namespace: Option[Name], 
     nme: TermName, 

--- a/avrohugger-core/src/main/scala/input/reflectivecompilation/schemagen/RecordSchemaGenerator.scala
+++ b/avrohugger-core/src/main/scala/input/reflectivecompilation/schemagen/RecordSchemaGenerator.scala
@@ -17,6 +17,7 @@ import scala.jdk.CollectionConverters._
 
 object RecordSchemaGenerator  {
 
+  @deprecated("Reflective compilation will no longer be supported", "avrohugger 1.5.0")
   def generateSchema(
     className: String, 
     namespace: Option[Name], 

--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ lazy val avroVersion = "1.11.1"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "1.4.0",
+  version := "1.5.0",
   ThisBuild / versionScheme := Some("semver-spec"),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
   Test / scalacOptions ++= Seq("-Yrangepos"),
-  scalaVersion := "2.13.10",
-  crossScalaVersions := Seq("2.12.17", scalaVersion.value),
+  scalaVersion := "2.13.11",
+  crossScalaVersions := Seq("2.12.18", scalaVersion.value),
   libraryDependencies += "org.apache.avro" % "avro" % avroVersion,
   libraryDependencies += "org.apache.avro" % "avro-compiler" % avroVersion,
   libraryDependencies := { CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0


### PR DESCRIPTION
- Bump Scala and sbt dependencies 
- Deprecates scavro format and reflective compilation (scavro format and reflective compilation will no longer be supported in avrohugger 2)