### PR TITLE
bug of not importing CoProduct

### DIFF
--- a/avrohugger-core/src/test/avro/unions_with_coproduct.avsc
+++ b/avrohugger-core/src/test/avro/unions_with_coproduct.avsc
@@ -1,0 +1,85 @@
+[
+  {
+    "namespace": "com.example.avrohugger.unions_with_coproduct_avsc",
+    "name": "r1",
+    "type": "record",
+    "fields": [
+      {
+        "name": "f1",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "namespace": "com.example.avrohugger.unions_with_coproduct_avsc",
+    "name": "r2",
+    "type": "record",
+    "fields": [
+      {
+        "name": "f2",
+        "type": "double"
+      }
+    ]
+  },
+  {
+    "namespace": "com.example.avrohugger.unions_with_coproduct_avsc",
+    "name": "r3",
+    "type": "record",
+    "fields": [
+      {
+        "name": "f3",
+        "type": "boolean"
+      }
+    ]
+  },
+  {
+    "namespace": "com.example.avrohugger.unions_with_coproduct_avsc",
+    "name": "s",
+    "type": "record",
+    "fields": [
+      {
+        "name": "s",
+        "type": "string"
+      },
+      {
+        "name": "ns",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      {
+        "name": "multi2",
+        "type": [
+          "r1",
+          "r2"
+        ]
+      },
+      {
+        "name": "multi2opt",
+        "type": [
+          "null",
+          "r1",
+          "r2"
+        ]
+      },
+      {
+        "name": "multi3",
+        "type": [
+          "r3",
+          "r1",
+          "r2"
+        ]
+      },
+      {
+        "name": "multi3opt",
+        "type": [
+          "null",
+          "r3",
+          "r1",
+          "r2"
+        ]
+      }
+    ]
+  }
+]

--- a/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/r1.scala
+++ b/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/r1.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc
+
+import scala.annotation.switch
+
+final case class r1(var f1: Int) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(0)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        f1
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.f1 = {
+        value
+      }.asInstanceOf[Int]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc.r1.SCHEMA$
+}
+
+object r1 {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"r1\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc\",\"fields\":[{\"name\":\"f1\",\"type\":\"int\"}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/r2.scala
+++ b/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/r2.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc
+
+import scala.annotation.switch
+
+final case class r2(var f2: Double) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(0.0)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        f2
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.f2 = {
+        value
+      }.asInstanceOf[Double]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc.r2.SCHEMA$
+}
+
+object r2 {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"r2\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc\",\"fields\":[{\"name\":\"f2\",\"type\":\"double\"}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/r3.scala
+++ b/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/r3.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc
+
+import scala.annotation.switch
+
+final case class r3(var f3: Boolean) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(false)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        f3
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.f3 = {
+        value
+      }.asInstanceOf[Boolean]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc.r3.SCHEMA$
+}
+
+object r3 {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"r3\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc\",\"fields\":[{\"name\":\"f3\",\"type\":\"boolean\"}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/s.scala
+++ b/avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/s.scala
@@ -1,0 +1,80 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc
+
+import scala.annotation.switch
+
+import shapeless.{:+:, CNil}
+
+final case class s(var s: String, var ns: Option[String], var multi2: Either[com.example.avrohugger.unions_with_coproduct_avsc.r1, com.example.avrohugger.unions_with_coproduct_avsc.r2], var multi2opt: Option[Either[com.example.avrohugger.unions_with_coproduct_avsc.r1, com.example.avrohugger.unions_with_coproduct_avsc.r2]], var multi3: com.example.avrohugger.unions_with_coproduct_avsc.r3 :+: com.example.avrohugger.unions_with_coproduct_avsc.r1 :+: com.example.avrohugger.unions_with_coproduct_avsc.r2 :+: CNil, var multi3opt: Option[com.example.avrohugger.unions_with_coproduct_avsc.r3 :+: com.example.avrohugger.unions_with_coproduct_avsc.r1 :+: com.example.avrohugger.unions_with_coproduct_avsc.r2 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this("", None, Left(new r1), None, Coproduct[r3 :+: r1 :+: r2 :+: CNil](new r3), None)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        s
+      }.asInstanceOf[AnyRef]
+      case 1 => {
+        ns match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case 2 => {
+        multi2
+      }.asInstanceOf[AnyRef]
+      case 3 => {
+        multi2opt match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case 4 => {
+        multi3
+      }.asInstanceOf[AnyRef]
+      case 5 => {
+        multi3opt match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.s = {
+        value.toString
+      }.asInstanceOf[String]
+      case 1 => this.ns = {
+        value match {
+          case null => None
+          case _ => Some(value.toString)
+        }
+      }.asInstanceOf[Option[String]]
+      case 2 => this.multi2 = {
+        value
+      }.asInstanceOf[Either[com.example.avrohugger.unions_with_coproduct_avsc.r1, com.example.avrohugger.unions_with_coproduct_avsc.r2]]
+      case 3 => this.multi2opt = {
+        value match {
+          case null => None
+          case _ => Some(value)
+        }
+      }.asInstanceOf[Option[Either[com.example.avrohugger.unions_with_coproduct_avsc.r1, com.example.avrohugger.unions_with_coproduct_avsc.r2]]]
+      case 4 => this.multi3 = {
+        value
+      }.asInstanceOf[com.example.avrohugger.unions_with_coproduct_avsc.r3 :+: com.example.avrohugger.unions_with_coproduct_avsc.r1 :+: com.example.avrohugger.unions_with_coproduct_avsc.r2 :+: CNil]
+      case 5 => this.multi3opt = {
+        value match {
+          case null => None
+          case _ => Some(value)
+        }
+      }.asInstanceOf[Option[com.example.avrohugger.unions_with_coproduct_avsc.r3 :+: com.example.avrohugger.unions_with_coproduct_avsc.r1 :+: com.example.avrohugger.unions_with_coproduct_avsc.r2 :+: CNil]]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc.s.SCHEMA$
+}
+
+object s {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"s\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc\",\"fields\":[{\"name\":\"s\",\"type\":\"string\"},{\"name\":\"ns\",\"type\":[\"null\",\"string\"]},{\"name\":\"multi2\",\"type\":[{\"type\":\"record\",\"name\":\"r1\",\"fields\":[{\"name\":\"f1\",\"type\":\"int\"}]},{\"type\":\"record\",\"name\":\"r2\",\"fields\":[{\"name\":\"f2\",\"type\":\"double\"}]}]},{\"name\":\"multi2opt\",\"type\":[\"null\",\"r1\",\"r2\"]},{\"name\":\"multi3\",\"type\":[{\"type\":\"record\",\"name\":\"r3\",\"fields\":[{\"name\":\"f3\",\"type\":\"boolean\"}]},\"r1\",\"r2\"]},{\"name\":\"multi3opt\",\"type\":[\"null\",\"r3\",\"r1\",\"r2\"]}]}")
+}

--- a/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
@@ -6,6 +6,7 @@ import avrohugger._
 import avrohugger.format.SpecificRecord
 import avrohugger.types._
 import org.specs2._
+import org.specs2.execute.Result
 
 import java.io.File
 import scala.util.Try
@@ -34,6 +35,7 @@ class SpecificFileToFileSpec extends Specification {
       correctly generate default values $e16
 
       correctly generate union values with shapeless Coproduct $e18
+      correctly generate union values with shapeless Coproduct from avsc $e19
 
 
       correctly generate a protocol with no ADT when asked $e21
@@ -280,6 +282,20 @@ class SpecificFileToFileSpec extends Specification {
     val source = util.Util.readFile("target/generated-sources/specific/example/idl/WithShapelessCoproduct.scala")
 
     source === util.Util.readFile("avrohugger-core/src/test/expected/specific/example/idl/WithShapelessCoproduct.scala")
+  }
+
+  def e19 = {
+    val inOrderSchema = new java.io.File("avrohugger-core/src/test/avro/unions_with_coproduct.avsc")
+    val gen = new Generator(format = SpecificRecord)
+    val outDir = gen.defaultOutputDir + "/specific/"
+    gen.fileToFile(inOrderSchema, outDir)
+
+    val classes = List("r1", "r2", "r3", "s")
+    val sources = classes.map(className => util.Util.readFile(s"avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/$className.scala"))
+
+    Result.foreach(classes.zip(sources)){ case (className, expect) =>
+      util.Util.readFile(s"target/generated-sources/specific/com/example/avrohugger/unions_with_coproduct_avsc/$className.scala") === expect
+    }
   }
 
   def e21 = {


### PR DESCRIPTION
This PR doesn't actually fix anything but only shows a bug. Added a tested case which is passing but should fail.(`avrohugger-core/src/test/expected/specific/com/example/avrohugger/unions_with_coproduct_avsc/s.scala` should include import of `CoProduct` but it doesn't, hence the test currently passes.)

I don't have the next 24h to try and fix this, but if anyone else has the fix, feel free to commit on top.