### PR TITLE
fix using coproduct for non-coproduct

### DIFF
--- a/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
@@ -76,7 +76,7 @@ object DefaultParamMatcher {
       case Schema.Type.ARRAY   =>
         CustomDefaultParamMatcher.checkCustomArrayType(typeMatcher.avroScalaTypes.array) DOT "empty"
       case Schema.Type.MAP     =>
-        MAKE_MAP(LIT("") ANY_-> asDefaultParam(classStore, avroSchema.getValueType, typeMatcher))
+        ID("Map") DOT "empty"
     }
   }
 

--- a/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
@@ -68,6 +68,8 @@ object DefaultParamMatcher {
       case Schema.Type.UNION =>
         val schemas = avroSchema.getTypes.asScala.toList
         if (avroSchema.isNullable) NONE
+        else if (schemas.size == 1 && !typeMatcher.avroScalaTypes.union.useCoproductForLoneNonNullType)
+          asDefaultParam(classStore, schemas.head, typeMatcher)
         else if (schemas.size == 2 && typeMatcher.avroScalaTypes.union.useEitherForTwoNonNullTypes)
           LEFT(asDefaultParam(classStore, schemas.head, typeMatcher))
         else COPRODUCT(asDefaultParam(classStore, schemas.head, typeMatcher), schemas.map(typeMatcher.toScalaType(classStore, None, _).safeToString))

--- a/avrohugger-core/src/main/scala/types/ComplexAvroScalaTypes.scala
+++ b/avrohugger-core/src/main/scala/types/ComplexAvroScalaTypes.scala
@@ -19,9 +19,13 @@ case object EnumAsScalaString extends AvroScalaEnumType
 sealed trait AvroScalaUnionType extends Product with Serializable {
   val useEitherForTwoNonNullTypes: Boolean = false
 
+  val useCoproductForLoneNonNullType: Boolean = false
+
 }
 
-case object OptionalShapelessCoproduct extends AvroScalaUnionType
+case object OptionalShapelessCoproduct extends AvroScalaUnionType {
+  override val useCoproductForLoneNonNullType: Boolean = true
+}
 case object OptionShapelessCoproduct extends AvroScalaUnionType
 case object OptionEitherShapelessCoproduct extends AvroScalaUnionType {
   override val useEitherForTwoNonNullTypes: Boolean = true

--- a/avrohugger-core/src/test/avro/unions_with_coproduct2.avsc
+++ b/avrohugger-core/src/test/avro/unions_with_coproduct2.avsc
@@ -1,6 +1,22 @@
 [
   {
     "namespace": "com.example.avrohugger.unions_with_coproduct_avsc2",
+    "name": "UnionOfOneNonNullType",
+    "type": "record",
+    "fields": [
+      {
+        "name": "f3",
+        "type": [
+          {
+            "type": "map",
+            "values": "string"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "namespace": "com.example.avrohugger.unions_with_coproduct_avsc2",
     "name": "UnionOfNullWithOneNonNullType",
     "type": "record",
     "fields": [

--- a/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -4,7 +4,7 @@ package com.example.avrohugger.unions_with_coproduct_avsc2
 import scala.annotation.switch
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(Map("" -> ""))
+  def this() = this(Map.empty)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc2
+
+import scala.annotation.switch
+
+final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        f3
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.f3 = {
+        value
+      }.asInstanceOf[Map[String, String]]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc2.UnionOfOneNonNullType.SCHEMA$
+}
+
+object UnionOfOneNonNullType {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"UnionOfOneNonNullType\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc2\",\"fields\":[{\"name\":\"f3\",\"type\":[{\"type\":\"map\",\"values\":\"string\"}]}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -4,7 +4,7 @@ package com.example.avrohugger.unions_with_coproduct_avsc2
 import scala.annotation.switch
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def this() = this(Map("" -> ""))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -4,7 +4,7 @@ package com.example.avrohugger.unions_with_coproduct_avsc2
 import scala.annotation.switch
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(Map("" -> ""))
+  def this() = this(Map.empty)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -1,0 +1,30 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc2
+
+import scala.annotation.switch
+
+final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        f3
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.f3 = {
+        value
+      }.asInstanceOf[Map[String, String]]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc2.UnionOfOneNonNullType.SCHEMA$
+}
+
+object UnionOfOneNonNullType {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"UnionOfOneNonNullType\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc2\",\"fields\":[{\"name\":\"f3\",\"type\":[{\"type\":\"map\",\"values\":\"string\"}]}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -4,7 +4,7 @@ package com.example.avrohugger.unions_with_coproduct_avsc2
 import scala.annotation.switch
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def this() = this(Map("" -> ""))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -1,0 +1,32 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.example.avrohugger.unions_with_coproduct_avsc2
+
+import scala.annotation.switch
+
+import shapeless.{:+:, CNil, Coproduct}
+
+final case class UnionOfOneNonNullType(var f3: Map[String, String] :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        f3
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.f3 = {
+        value
+      }.asInstanceOf[Map[String, String] :+: CNil]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = com.example.avrohugger.unions_with_coproduct_avsc2.UnionOfOneNonNullType.SCHEMA$
+}
+
+object UnionOfOneNonNullType {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"UnionOfOneNonNullType\",\"namespace\":\"com.example.avrohugger.unions_with_coproduct_avsc2\",\"fields\":[{\"name\":\"f3\",\"type\":[{\"type\":\"map\",\"values\":\"string\"}]}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -6,7 +6,7 @@ import scala.annotation.switch
 import shapeless.{:+:, CNil, Coproduct}
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String] :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map.empty))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificFileToFileSpec.scala
@@ -7,6 +7,7 @@ import avrohugger.format.SpecificRecord
 import avrohugger.types._
 import org.specs2._
 import org.specs2.execute.Result
+import util.Util.containExpectedContentIn
 
 import java.io.File
 import scala.util.Try
@@ -305,17 +306,18 @@ class SpecificFileToFileSpec extends Specification {
     val outDir = gen.defaultOutputDir + s"/specific/$unionType"
     gen.fileToFile(inOrderSchema, outDir)
 
-    val classes = List(
+    Result.forall(List(
+      "UnionOfOneNonNullType",
       "UnionOfNullWithOneNonNullType",
       "UnionOfTwoNonNullTypes",
       "UnionOfNullWithTwoNonNullTypes",
       "UnionOfMoreThanTwoNonNullTypes",
       "UnionOfNullWithMoreThanTwoNonNullTypes"
-    )
-    val sources = classes.map(className => util.Util.readFile(s"avrohugger-core/src/test/expected/specific/$unionType/com/example/avrohugger/unions_with_coproduct_avsc2/$className.scala"))
+    )) { className =>
 
-    Result.forall(classes.zip(sources)) { case (className, expect) =>
-      util.Util.readFile(s"target/generated-sources/specific/$unionType/com/example/avrohugger/unions_with_coproduct_avsc2/$className.scala") === expect
+      val generatedFile = s"target/generated-sources/specific/$unionType/com/example/avrohugger/unions_with_coproduct_avsc2/$className.scala"
+      val expectationFile = s"avrohugger-core/src/test/expected/specific/$unionType/com/example/avrohugger/unions_with_coproduct_avsc2/$className.scala"
+      generatedFile must containExpectedContentIn(expectationFile)
     }
   }
 

--- a/avrohugger-core/src/test/scala/util/Util.scala
+++ b/avrohugger-core/src/test/scala/util/Util.scala
@@ -1,5 +1,7 @@
 package util
 
+import org.specs2.matcher.{Expectable, MatchResult, Matcher}
+
 object Util {
 
   def readFile(fileName: String, maxTries: Int = 3): String = {
@@ -26,4 +28,10 @@ object Util {
       case e: Throwable => false
     }
 
+  def containExpectedContentIn(expectPath: String): Matcher[String] = new Matcher[String] {
+    override def apply[S <: String](t: Expectable[S]): MatchResult[S] = {
+      val generatedPath = t.value
+      result(readFile(generatedPath) == readFile(expectPath), s"$generatedPath === $expectPath", s"\ndiff -ruBbE $expectPath $generatedPath", t)
+    }
+  }
 }


### PR DESCRIPTION
As such:

```diff
diff --git a/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala b/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
index 85d4ff6..1438735 100644
--- a/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionEitherShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -4,7 +4,7 @@ package com.example.avrohugger.unions_with_coproduct_avsc2
 import scala.annotation.switch
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def this() = this(Map())
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
diff --git a/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala b/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
index 85d4ff6..1438735 100644
--- a/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -4,7 +4,7 @@ package com.example.avrohugger.unions_with_coproduct_avsc2
 import scala.annotation.switch
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String]) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def this() = this(Map())
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
diff --git a/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala b/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
index eed1e7a..79e7525 100644
--- a/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
+++ b/avrohugger-core/src/test/expected/specific/OptionalShapelessCoproduct/com/example/avrohugger/unions_with_coproduct_avsc2/UnionOfOneNonNullType.scala
@@ -6,7 +6,7 @@ import scala.annotation.switch
 import shapeless.{:+:, CNil, Coproduct}
 
 final case class UnionOfOneNonNullType(var f3: Map[String, String] :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map("" -> "")))
+  def this() = this(shapeless.Coproduct[Map[String, String] :+: CNil](Map()))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
```