### PR TITLE
Bump treehugger from 0.4.4 to 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val avrohugger = (project in file("."))
 lazy val `avrohugger-core` = (project in file("avrohugger-core"))
   .settings(
     commonSettings,
-    libraryDependencies += ("com.eed3si9n" %% "treehugger" % "0.4.4").cross(CrossVersion.for3Use2_13),
+    libraryDependencies += ("com.eed3si9n" %% "treehugger" % "0.5.0").cross(CrossVersion.for3Use2_13),
     Compile / sourceGenerators += addScalaVersionFile.taskValue
   )
 


### PR DESCRIPTION
## Summary

Bumps `treehugger` dependency from `0.4.4` to `0.5.0`.

## Why

treehugger `0.4.4` has thread-safety bugs in `Types.scala` ([#68](https://github.com/eed3si9n/treehugger/issues/68), [#70](https://github.com/eed3si9n/treehugger/issues/70)) that cause intermittent `NullPointerException` when avrohugger is used in parallel SBT builds (e.g., `sbt-avrohugger` generating code for multiple subprojects concurrently).

This is the root cause of https://github.com/julianpeeters/avrohugger/issues/209.

treehugger `0.5.0` ([release notes](https://github.com/eed3si9n/treehugger/releases/tag/v0.5.0)) includes the fix via [eed3si9n/treehugger#73](https://github.com/eed3si9n/treehugger/pull/73).

## Verification

- Compiled and tested against Scala 2.12, 2.13, and 3.3 — all 243 tests pass.
- No source changes required — treehugger 0.5.0 is a drop-in replacement for 0.4.4.